### PR TITLE
Add SleepLog properties

### DIFF
--- a/Fitbit/Models/SleepLog.cs
+++ b/Fitbit/Models/SleepLog.cs
@@ -19,5 +19,9 @@ namespace Fitbit.Models
         public int MinutesToFallAsleep { get; set; }
         public DateTime StartTime { get; set; }
         public int TimeInBed { get; set; }
+        public int AwakeCount { get; set; }
+        public int AwakeDuration { get; set; }
+        public int RestlessCount { get; set; }
+        public int RestlessDuration { get; set; }
     }
 }


### PR DESCRIPTION
Added new properties exposed by FitBit API: AwakeCount, AwakeDuration, RestlessCount and RestlessDuration.

Reference: https://wiki.fitbit.com/display/API/API-Get-Sleep
