### PR TITLE
Add in EmptyDateToMinDateConverter to the JsonDotNetSerializer setup - fixes #65

### DIFF
--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -133,6 +133,7 @@
     <None Include="SampleData\GetActivities.json" />
     <None Include="SampleData\GetBloodPressure.json" />
     <None Include="SampleData\GetBodyMeasurements.json" />
+    <None Include="SampleData\GetFriends-Single-2.json" />
     <None Include="SampleData\GetHeartRate.json" />
     <None Include="SampleData\GetWater-WaterData.json" />
     <None Include="SampleData\GetWeight.json" />

--- a/Fitbit.Portable.Tests/FriendsTests.cs
+++ b/Fitbit.Portable.Tests/FriendsTests.cs
@@ -130,6 +130,18 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
+        public void Can_Deserialize_Friends_Single_NullDateOfBirth()
+        {
+            string content = SampleDataHelper.GetContent("GetFriends-Single-2.json");
+            var deserializer = new JsonDotNetSerializer();
+
+            List<UserProfile> friends = deserializer.GetFriends(content);
+
+            Assert.IsNotNull(friends);
+            ValidateSingleFriendNullDateOfBirth(friends);
+        }
+
+        [Test] [Category("Portable")]
         public void Can_Deserialize_Friends_None()
         {
             string content = SampleDataHelper.GetContent("GetFriends-None.json");
@@ -230,6 +242,31 @@ namespace Fitbit.Portable.Tests
             Assert.AreEqual(0, friend.StrideLengthWalking);
             Assert.AreEqual("Europe/London", friend.Timezone);
             Assert.AreEqual(0, friend.Weight);
+        }
+
+        private void ValidateSingleFriendNullDateOfBirth(List<UserProfile> friends)
+        {  
+            Assert.IsTrue(friends.Count == 1);  
+        
+            var friend = friends.First();  
+            Assert.AreEqual("http://www.fitbit.com/images/profile/defaultProfile_100_female.gif", friend.Avatar);  
+            Assert.AreEqual("http://www.fitbit.com/images/profile/defaultProfile_150_female.gif", friend.Avatar150);  
+            Assert.AreEqual("GB", friend.Country);  
+            Assert.AreEqual(DateTime.MinValue, friend.DateOfBirth);  
+            Assert.AreEqual("Laura", friend.DisplayName);  
+            Assert.AreEqual("24WXXX", friend.EncodedId);  
+            Assert.AreEqual("", friend.FullName);  
+            Assert.AreEqual(Gender.FEMALE, friend.Gender);  
+            Assert.AreEqual(165, friend.Height);  
+            Assert.AreEqual("en_GB", friend.Locale);  
+            Assert.AreEqual(DateTime.Parse("2013-02-01"), friend.MemberSince);  
+            Assert.AreEqual("", friend.Nickname);  
+            Assert.AreEqual(3600000, friend.OffsetFromUTCMillis);  
+            Assert.AreEqual("SUNDAY", friend.StartDayOfWeek);  
+            Assert.AreEqual(0, friend.StrideLengthRunning);  
+            Assert.AreEqual(0, friend.StrideLengthWalking);  
+            Assert.AreEqual("Europe/London", friend.Timezone);  
+            Assert.AreEqual(0, friend.Weight);  
         }
     }
 }

--- a/Fitbit.Portable.Tests/JsonDotNetSerializerTests.cs
+++ b/Fitbit.Portable.Tests/JsonDotNetSerializerTests.cs
@@ -1,4 +1,5 @@
-﻿using Fitbit.Api.Portable;
+﻿using System;
+using Fitbit.Api.Portable;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -12,6 +13,10 @@ namespace Fitbit.Portable.Tests
         {
             [JsonProperty("testproperty")]
             public string TestProperty { get; set; }
+
+            [JsonProperty("mydate")]  
+            public DateTime MyDate { get; set; }
+
 
             // todo: array etc.
         }
@@ -52,5 +57,25 @@ namespace Fitbit.Portable.Tests
             Assert.IsNotNull(value);
             Assert.AreEqual("bob", value.TestProperty);
         }
+
+        [Test]  [Category("Portable")]  
+        public void DateParsingSuccess()
+        {  
+            string data = "{\"mydate\" : \"1970-01-01\" }";  
+            var serializer = new JsonDotNetSerializer();  
+            var value = serializer.Deserialize<TestClass>(data);  
+            Assert.IsNotNull(value);  
+            Assert.AreEqual(new DateTime(1970, 1, 1), value.MyDate);  
+        }  
+        
+        [Test]  [Category("Portable")]  
+        public void DateParsingEmptySuccess()
+        {  
+            string data = "{\"mydate\" : \"\" }";  
+            var serializer = new JsonDotNetSerializer();  
+            var value = serializer.Deserialize<TestClass>(data);  
+            Assert.IsNotNull(value);  
+            Assert.AreEqual(DateTime.MinValue, value.MyDate);  
+        } 
     }
 }

--- a/Fitbit.Portable.Tests/SampleData/GetFriends-Single-2.json
+++ b/Fitbit.Portable.Tests/SampleData/GetFriends-Single-2.json
@@ -1,0 +1,26 @@
+﻿{
+  "friends": [
+    {
+      "user": {
+        "avatar": "http://www.fitbit.com/images/profile/defaultProfile_100_female.gif",
+        "avatar150": "http://www.fitbit.com/images/profile/defaultProfile_150_female.gif",
+        "country": "GB",
+        "dateOfBirth": "",
+        "displayName": "Laura",
+        "encodedId": "24WXXX",
+        "fullName": "",
+        "gender": "FEMALE",
+        "height": 165,
+        "locale": "en_GB",
+        "memberSince": "2013-02-01",
+        "nickname": "",
+        "offsetFromUTCMillis": 3600000,
+        "startDayOfWeek": "SUNDAY",
+        "strideLengthRunning": 0,
+        "strideLengthWalking": 0,
+        "timezone": "Europe/London",
+        "weight": 0
+      }
+    }
+  ]
+}

--- a/Fitbit.Portable/EmptyDateToMinDateConverter.cs
+++ b/Fitbit.Portable/EmptyDateToMinDateConverter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Fitbit.Api.Portable
+{
+    internal class EmptyDateToMinDateConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            DateTime date = (DateTime)value;
+            if (date == DateTime.MinValue)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteValue(date);
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (CanConvert(objectType))
+            {
+                if (string.IsNullOrWhiteSpace(reader.Value.ToString()))
+                {
+                    return DateTime.MinValue;
+                }
+
+                return DateTime.Parse(reader.Value.ToString());
+            }
+            return null;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(DateTime));
+        }
+    }
+}

--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Authenticator.cs" />
     <Compile Include="Authenticator2.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="EmptyDateToMinDateConverter.cs" />
     <Compile Include="FitbitClient.cs" />
     <Compile Include="FitbitClientHelperExtensions.cs" />
     <Compile Include="IAuthorization.cs" />

--- a/Fitbit.Portable/JsonDotNetSerializer.cs
+++ b/Fitbit.Portable/JsonDotNetSerializer.cs
@@ -1,9 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Fitbit.Api.Portable
 {
     internal class JsonDotNetSerializer
     {
+        private readonly JsonSerializer _jsonSerializer;
+
+        public JsonDotNetSerializer()
+        {
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.Converters.Add(new EmptyDateToMinDateConverter());
+            _jsonSerializer = JsonSerializer.CreateDefault(settings);
+        }
+
         /// <summary>
         /// Root property value; only required if trying to access nested information or an array is hanging off a property
         /// </summary>
@@ -27,8 +37,8 @@ namespace Fitbit.Api.Portable
                 return default(T);
             }
 
-            T result = string.IsNullOrWhiteSpace(RootProperty) ? token.ToObject<T>() : token[RootProperty].ToObject<T>();
-            return result;            
+            T result = string.IsNullOrWhiteSpace(RootProperty) ? token.ToObject<T>(_jsonSerializer) : token[RootProperty].ToObject<T>(_jsonSerializer);
+            return result;
         }
     }
 }


### PR DESCRIPTION
Update the json serializer to have a custom converter for the empty string DateTime values for Date of Birth