### PR TITLE
Relocate SleepData processing out of FitbitClient

### DIFF
--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="BodyMeasurementTests.cs" />
     <Compile Include="DayActivityTests.cs" />
     <Compile Include="FatTests.cs" />
+    <Compile Include="FitbitClientExtensionsTests.cs" />
     <Compile Include="FitbitClientHelperExtensionsTests.cs" />
     <Compile Include="FitbitClientTests.cs" />
     <Compile Include="FoodTests.cs" />

--- a/Fitbit.Portable.Tests/FitbitClientExtensionsTests.cs
+++ b/Fitbit.Portable.Tests/FitbitClientExtensionsTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using Fitbit.Api.Portable;
+using Fitbit.Models;
+using NUnit.Framework;
+
+namespace Fitbit.Portable.Tests
+{
+    [TestFixture]
+    public class FitbitClientExtensionsTests
+    {
+        [Test]
+        [Category("Portable")]
+        public void ProcessSleepData_NullHandled()
+        {
+            FitbitClientExtensions.ProcessSleepData(null);
+        }
+
+        [Test]
+        [Category("Portable")]
+        public void ProcessSleepData_NullSleepHandled()
+        {
+            FitbitClientExtensions.ProcessSleepData(new SleepData());
+        }
+
+        [Test]
+        [Category("Portable")]
+        public void ProcessSleepData_NullMinuteDataHandled()
+        {
+            var sleep = new SleepData
+            {
+                Sleep = new List<SleepLog>
+                {
+                    new SleepLog()
+                }
+            };
+            FitbitClientExtensions.ProcessSleepData(sleep);
+        }
+
+        [Test]
+        [Category("Portable")]
+        public void ProcessSleepData_MinuteDataToday()
+        {
+            var sleep = new SleepData
+            {
+                Sleep = new List<SleepLog>
+                {
+                    new SleepLog
+                    {
+                        StartTime = new DateTime(2014, 10,10, 22, 0, 0),
+                        MinuteData = new List<MinuteData>
+                        {
+                            new MinuteData
+                            {
+                                DateTime = new DateTime(1900, 1, 1, 23, 0, 0) // the date part is derived
+                            }
+                        }
+                    }
+                }
+            };
+
+            FitbitClientExtensions.ProcessSleepData(sleep);
+
+            Assert.AreEqual(new DateTime(2014, 10, 10, 23, 0, 0), sleep.Sleep[0].MinuteData[0].DateTime);
+        }
+
+        [Test]
+        [Category("Portable")]
+        public void ProcessSleepData_MinuteDataTomorrow()
+        {
+            var sleep = new SleepData
+            {
+                Sleep = new List<SleepLog>
+                {
+                    new SleepLog
+                    {
+                        StartTime = new DateTime(2014, 10,10, 22, 0, 0),
+                        MinuteData = new List<MinuteData>
+                        {
+                            new MinuteData
+                            {
+                                DateTime = new DateTime(1900, 1, 1, 4, 0, 0) // the date part is derived
+                            }
+                        }
+                    }
+                }
+            };
+
+            FitbitClientExtensions.ProcessSleepData(sleep);
+
+            Assert.AreEqual(new DateTime(2014, 10, 11, 4, 0, 0), sleep.Sleep[0].MinuteData[0].DateTime);
+        }
+    }
+}

--- a/Fitbit.Portable.Tests/FitbitClientTests.cs
+++ b/Fitbit.Portable.Tests/FitbitClientTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using Fitbit.Api.Portable;
-using Fitbit.Models;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -70,87 +68,6 @@ namespace Fitbit.Portable.Tests
         {
             var client = new FitbitClient("key", "secret", "access", "accessToken");
             Assert.IsNotNull(client.HttpClient);
-        }
-
-        // todo: doesn't seem to be the right place for this; it'll do at the moment
-        [Test] [Category("Portable")]
-        public void ProcessSleepData_NullHandled()
-        {
-            var client = new FitbitClient("key", "secret", "token", "secret");
-            client.ProcessSleepData(null);
-        }
-
-        [Test] [Category("Portable")]
-        public void ProcessSleepData_NullSleepHandled()
-        {
-            var client = new FitbitClient("key", "secret", "token", "secret");
-            client.ProcessSleepData(new SleepData());
-        }
-
-        [Test] [Category("Portable")]
-        public void ProcessSleepData_NullMinuteDataHandled()
-        {
-            var client = new FitbitClient("key", "secret", "token", "secret");
-            var sleep = new SleepData
-            {
-                Sleep = new List<SleepLog>
-                {
-                    new SleepLog()
-                }
-            };
-            client.ProcessSleepData(sleep);
-        }
-
-        [Test] [Category("Portable")]
-        public void ProcessSleepData_MinuteDataToday()
-        {
-            var client = new FitbitClient("key", "secret", "token", "secret");
-            var sleep = new SleepData
-            {
-                Sleep = new List<SleepLog>
-                {
-                    new SleepLog
-                    {
-                        StartTime = new DateTime(2014, 10,10, 22, 0, 0),
-                        MinuteData = new List<MinuteData>
-                        {
-                            new MinuteData
-                            {
-                                DateTime = new DateTime(1900, 1, 1, 23, 0, 0) // the date part is derived
-                            }
-                        }
-                    }
-                }
-            };
-            client.ProcessSleepData(sleep);
-
-            Assert.AreEqual(new DateTime(2014, 10 ,10, 23, 0, 0), sleep.Sleep[0].MinuteData[0].DateTime);
-        }
-
-        [Test] [Category("Portable")]
-        public void ProcessSleepData_MinuteDataTomorrow()
-        {
-            var client = new FitbitClient("key", "secret", "token", "secret");
-            var sleep = new SleepData
-            {
-                Sleep = new List<SleepLog>
-                {
-                    new SleepLog
-                    {
-                        StartTime = new DateTime(2014, 10,10, 22, 0, 0),
-                        MinuteData = new List<MinuteData>
-                        {
-                            new MinuteData
-                            {
-                                DateTime = new DateTime(1900, 1, 1, 4, 0, 0) // the date part is derived
-                            }
-                        }
-                    }
-                }
-            };
-            client.ProcessSleepData(sleep);
-
-            Assert.AreEqual(new DateTime(2014, 10, 11, 4, 0, 0), sleep.Sleep[0].MinuteData[0].DateTime);
         }
     }
 }

--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Authenticator2.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="FitbitClient.cs" />
+    <Compile Include="FitbitClientExtensions.cs" />
     <Compile Include="FitbitClientHelperExtensions.cs" />
     <Compile Include="IAuthorization.cs" />
     <Compile Include="IFitbitClient.cs" />

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -145,44 +145,8 @@ namespace Fitbit.Api.Portable
             string responseBody = await response.Content.ReadAsStringAsync();
             var serializer = new JsonDotNetSerializer();
             var data = serializer.Deserialize<SleepData>(responseBody);
-            ProcessSleepData(data);
+            FitbitClientExtensions.ProcessSleepData(data);
             return data;
-        }
-
-        internal void ProcessSleepData(SleepData sleepData)
-        {
-            if ((sleepData != null) && (sleepData.Sleep != null))
-            {
-                foreach (var sleepLog in sleepData.Sleep)
-                {
-                    if (sleepLog.MinuteData == null)
-                        continue;
-
-                    int startSleepSeconds = sleepLog.StartTime.ToElapsedSeconds();
-
-                    for (int i = 0; i < sleepLog.MinuteData.Count; i++)
-                    {
-                        //work with a local minute data info instance
-                        var minuteData = sleepLog.MinuteData[i];
-
-                        // determine how many seconds have elapsed since mightnight in the date
-                        int currentSeconds = minuteData.DateTime.ToElapsedSeconds();
-
-                        // if the current time is post midnight then we've clicked over to the next day
-                        int daysToAdd = (currentSeconds < startSleepSeconds) ? 1 : 0;
-                        DateTime derivedDate = sleepLog.StartTime.AddDays(daysToAdd);
-
-                        // update the time value with the updated asociated date of the sleep log
-                        sleepLog.MinuteData[i].DateTime = new DateTime(
-                                                        derivedDate.Year,
-                                                        derivedDate.Month,
-                                                        derivedDate.Day,
-                                                        minuteData.DateTime.Hour,
-                                                        minuteData.DateTime.Minute,
-                                                        minuteData.DateTime.Second);
-                    }
-                }
-            }
         }
 
         /// <summary>

--- a/Fitbit.Portable/FitbitClientExtensions.cs
+++ b/Fitbit.Portable/FitbitClientExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Fitbit.Models;
+
+namespace Fitbit.Api.Portable
+{
+    internal static class FitbitClientExtensions
+    {
+        internal static void ProcessSleepData(SleepData sleepData)
+        {
+            if ((sleepData != null) && (sleepData.Sleep != null))
+            {
+                foreach (var sleepLog in sleepData.Sleep)
+                {
+                    if (sleepLog.MinuteData == null)
+                        continue;
+
+                    int startSleepSeconds = sleepLog.StartTime.ToElapsedSeconds();
+
+                    for (int i = 0; i < sleepLog.MinuteData.Count; i++)
+                    {
+                        //work with a local minute data info instance
+                        var minuteData = sleepLog.MinuteData[i];
+
+                        // determine how many seconds have elapsed since mightnight in the date
+                        int currentSeconds = minuteData.DateTime.ToElapsedSeconds();
+
+                        // if the current time is post midnight then we've clicked over to the next day
+                        int daysToAdd = (currentSeconds < startSleepSeconds) ? 1 : 0;
+                        DateTime derivedDate = sleepLog.StartTime.AddDays(daysToAdd);
+
+                        // update the time value with the updated asociated date of the sleep log
+                        sleepLog.MinuteData[i].DateTime = new DateTime(
+                                                        derivedDate.Year,
+                                                        derivedDate.Month,
+                                                        derivedDate.Day,
+                                                        minuteData.DateTime.Hour,
+                                                        minuteData.DateTime.Minute,
+                                                        minuteData.DateTime.Second);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
As part of the "keeping FitbitClient.cs tidy and clean" initiative the SleepData processing has bothered me for a while so I've moved it out and the associated tests.

Can't quite decide if I like the name of the class so happy to change if someone has a better suggestion.