### PR TITLE
#79 Re-enable tests for exceptions

### DIFF
--- a/Fitbit.Portable.Tests/BloodPressureTests.cs
+++ b/Fitbit.Portable.Tests/BloodPressureTests.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -35,21 +37,19 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetBloodPressureAsync_Errors()
+        public void GetBloodPressureAsync_Errors()
         {
-            var responseMessage = Helper.CreateErrorResponse();
+            var responseMessage = Helper.CreateErrorResponse(HttpStatusCode.BadRequest);
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
             {
                 Assert.AreEqual(HttpMethod.Get, message.Method);
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
+            
+            Func<Task<BloodPressureData>> result = () => fitbitClient.GetBloodPressureAsync(new DateTime(2014, 9, 27));
 
-            var response = await fitbitClient.GetBloodPressureAsync(new DateTime(2014, 9, 27));
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            result.ShouldThrow<FitbitRequestException>().Which.ApiErrors.Count.Should().Be(1);
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/BodyMeasurementTests.cs
+++ b/Fitbit.Portable.Tests/BodyMeasurementTests.cs
@@ -2,8 +2,10 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -35,10 +37,9 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetBodyMeasurementsAsync_Errors()
+        public void GetBodyMeasurementsAsync_Errors()
         {
-            var responseMessage = Helper.CreateErrorResponse();
+            var responseMessage = Helper.CreateErrorResponse(HttpStatusCode.Unauthorized);
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
             {
                 Assert.AreEqual(HttpMethod.Get, message.Method);
@@ -46,11 +47,9 @@ namespace Fitbit.Portable.Tests
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
 
-            var response = await fitbitClient.GetBodyMeasurementsAsync(new DateTime(2014, 9, 27));
+            Func<Task<BodyMeasurements>> result = () => fitbitClient.GetBodyMeasurementsAsync(new DateTime(2014, 9, 27));
 
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            result.ShouldThrow<FitbitRequestException>().Which.ApiErrors.Count.Should().Be(1);
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/DayActivityTests.cs
+++ b/Fitbit.Portable.Tests/DayActivityTests.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -36,10 +38,9 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetDayActivityAsync_Errors()
+        public void GetDayActivityAsync_Errors()
         {
-            var responseMessage = Helper.CreateErrorResponse();
+            var responseMessage = Helper.CreateErrorResponse(HttpStatusCode.Unauthorized);
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
             {
                 Assert.AreEqual(HttpMethod.Get, message.Method);
@@ -47,11 +48,9 @@ namespace Fitbit.Portable.Tests
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
 
-            var response = await fitbitClient.GetDayActivityAsync(new DateTime(2014, 9, 27));
+            Func<Task<Activity>> result = () => fitbitClient.GetDayActivityAsync(new DateTime(2014, 9, 27));
 
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            result.ShouldThrow<FitbitRequestException>().Which.ApiErrors.Count.Should().Be(1);
         }
 
         [Test] [Category("Portable")]
@@ -78,23 +77,20 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetDayActivitySummaryAsync_Errors()
+        public void GetDayActivitySummaryAsync_Errors()
         {
-            var responseMessage = Helper.CreateErrorResponse();
+            var responseMessage = Helper.CreateErrorResponse(HttpStatusCode.Forbidden);
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
             {
                 Assert.AreEqual(HttpMethod.Get, message.Method);
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
+            
+            Func<Task<Activity>> result = () => fitbitClient.GetDayActivityAsync(new DateTime(2014, 9, 27));
 
-            var response = await fitbitClient.GetDayActivitySummaryAsync(new DateTime(2014, 9, 27));
-
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
-        } 
+            result.ShouldThrow<FitbitRequestException>().Which.ApiErrors.Count.Should().Be(1);
+        }
 
         [Test] [Category("Portable")]
         public void Can_Deserialize_Activity()

--- a/Fitbit.Portable.Tests/DeviceTests.cs
+++ b/Fitbit.Portable.Tests/DeviceTests.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -61,8 +63,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetDevicesAsync_Failure_Errors()
+        public void GetDevicesAsync_Failure_Errors()
         {
             var responseMessage = Helper.CreateErrorResponse();
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
@@ -72,11 +73,9 @@ namespace Fitbit.Portable.Tests
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
 
-            var response = await fitbitClient.GetDevicesAsync();
+            Func<Task<List<Device>>> result = () => fitbitClient.GetDevicesAsync();
 
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            result.ShouldThrow<FitbitException>();
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -37,6 +37,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Fitbit\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
@@ -85,6 +93,8 @@
       <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/Fitbit.Portable.Tests/FoodTests.cs
+++ b/Fitbit.Portable.Tests/FoodTests.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -36,8 +38,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetFoodAsync_Errors()
+        public void GetFoodAsync_Errors()
         {
             var responseMessage = Helper.CreateErrorResponse();
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
@@ -47,11 +48,9 @@ namespace Fitbit.Portable.Tests
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
             
-            var response = await fitbitClient.GetFoodAsync(new DateTime(2014, 9, 27));
+            Func<Task<Food>> result = () => fitbitClient.GetFoodAsync(new DateTime(2014, 9, 27));
 
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            result.ShouldThrow<FitbitException>();
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/FriendsTests.cs
+++ b/Fitbit.Portable.Tests/FriendsTests.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -61,8 +63,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetFriendsAsync_Failure_Errors()
+        public void GetFriendsAsync_Failure_Errors()
         {
             var responseMessage = Helper.CreateErrorResponse();
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
@@ -72,11 +73,9 @@ namespace Fitbit.Portable.Tests
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
             
-            var response = await fitbitClient.GetFriendsAsync();
-            
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            Func<Task<List<UserProfile>>> result = () => fitbitClient.GetFriendsAsync();
+
+            result.ShouldThrow<FitbitException>();
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/Helper.cs
+++ b/Fitbit.Portable.Tests/Helper.cs
@@ -32,11 +32,26 @@ namespace Fitbit.Portable.Tests
         /// Unit test helper to create a mock HttpResponseMessage action which is errored
         /// </summary>
         /// <returns></returns>
-        public static Func<HttpResponseMessage> CreateErrorResponse()
+        public static Func<HttpResponseMessage> CreateErrorResponse(HttpStatusCode statusCode = HttpStatusCode.LengthRequired) // general error
         {
-            string content = SampleDataHelper.GetContent("ApiError.json");
+            string errorFilePath = "ApiError.json";
+            switch (statusCode)
+            {
+                case HttpStatusCode.Forbidden:
+                    errorFilePath = "ApiError-Request-Forbidden.json";
+                    break;
+
+                case HttpStatusCode.Unauthorized:
+                    errorFilePath = "ApiError-Request-Unauthorized.json";
+                    break;
+                case HttpStatusCode.BadRequest:
+                    errorFilePath = "ApiError-Request-BadRequest.json";
+                    break;
+            }
+
+            string content = SampleDataHelper.GetContent(errorFilePath);
             var responseMessage =
-                new Func<HttpResponseMessage>(() => new HttpResponseMessage(HttpStatusCode.NotFound) {Content = new StringContent(content)});
+                new Func<HttpResponseMessage>(() => new HttpResponseMessage(statusCode) {Content = new StringContent(content)});
             return responseMessage;
         }
     }

--- a/Fitbit.Portable.Tests/SleepTests.cs
+++ b/Fitbit.Portable.Tests/SleepTests.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -36,8 +38,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetUserProfileAsync_Failure_Errors()
+        public void GetUserProfileAsync_Failure_Errors()
         {
             var responseMessage = Helper.CreateErrorResponse();
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
@@ -47,11 +48,9 @@ namespace Fitbit.Portable.Tests
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
             
-            var response = await fitbitClient.GetSleepAsync(new DateTime(2014, 11, 11));
+            Func<Task<SleepData>> result = () => fitbitClient.GetSleepAsync(new DateTime(2014, 11, 11));
 
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            result.ShouldThrow<FitbitException>();
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/UserProfileTests.cs
+++ b/Fitbit.Portable.Tests/UserProfileTests.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -35,8 +38,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetUserProfileAsync_Failure_Errors()
+        public void GetUserProfileAsync_Failure_Errors()
         {
             var responseMessage = Helper.CreateErrorResponse();
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
@@ -46,11 +48,9 @@ namespace Fitbit.Portable.Tests
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
             
-            var response = await fitbitClient.GetFriendsAsync();
+            Func<Task<List<UserProfile>>> result = () => fitbitClient.GetFriendsAsync();
 
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            result.ShouldThrow<FitbitException>();
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/WaterTests.cs
+++ b/Fitbit.Portable.Tests/WaterTests.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Fitbit.Portable.Tests
@@ -36,8 +38,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [Ignore("Re-enable when exceptions have been introduced")]
-        public async void GetWaterAsync_Errors()
+        public void GetWaterAsync_Errors()
         {
             var responseMessage = Helper.CreateErrorResponse();
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
@@ -47,11 +48,9 @@ namespace Fitbit.Portable.Tests
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
             
-            var response = await fitbitClient.GetFoodAsync(new DateTime(2015, 1, 12));
+            Func<Task<Food>> result = () => fitbitClient.GetFoodAsync(new DateTime(2015, 1, 12));
 
-            //Assert.IsFalse(response.Success);
-            //Assert.IsNull(response.Data);
-            //Assert.AreEqual(1, response.Errors.Count);
+            result.ShouldThrow<FitbitException>();
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/WeightTests.cs
+++ b/Fitbit.Portable.Tests/WeightTests.cs
@@ -13,7 +13,7 @@ namespace Fitbit.Portable.Tests
     public class WeightTests
     {
         [Test] [Category("Portable")]
-        [ExpectedException(typeof (Exception))]
+        [ExpectedException(typeof (ArgumentOutOfRangeException))]
         public async void GetWeightAsync_DateRangePeriod_ThreeMonths()
         {
             var client = new FitbitClient("key", "secret", "access", "accessSecret");
@@ -21,7 +21,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [ExpectedException(typeof (Exception))]
+        [ExpectedException(typeof (ArgumentOutOfRangeException))]
         public async void GetWeightAsync_DateRangePeriod_SixMonths()
         {
             var client = new FitbitClient("key", "secret", "access", "accessSecret");
@@ -29,7 +29,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [ExpectedException(typeof (Exception))]
+        [ExpectedException(typeof (ArgumentOutOfRangeException))]
         public async void GetWeightAsync_DateRangePeriod_OneYear()
         {
             var client = new FitbitClient("key", "secret", "access", "accessSecret");
@@ -37,7 +37,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [ExpectedException(typeof (Exception))]
+        [ExpectedException(typeof (ArgumentOutOfRangeException))]
         public async void GetWeightAsync_DateRangePeriod_Max()
         {
             var client = new FitbitClient("key", "secret", "access", "accessSecret");
@@ -115,7 +115,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [ExpectedException(typeof (Exception))]
+        [ExpectedException(typeof (ArgumentOutOfRangeException))]
         public async void GetWeightAsync_DateRange_Span_Too_Large()
         {
             var fitbitClient = Helper.CreateFitbitClient(() => new HttpResponseMessage(), (r, c) => { });

--- a/Fitbit.Portable.Tests/packages.config
+++ b/Fitbit.Portable.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentAssertions" version="4.2.1" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -742,7 +742,7 @@ namespace Fitbit.Api.Portable
                     case HttpStatusCode.Unauthorized:
                     case HttpStatusCode.Forbidden:
                     case HttpStatusCode.NotFound:
-                        throw new FitbitRequestException(response.StatusCode) { ApiErrors = errors};
+                        throw new FitbitRequestException(response.StatusCode) { ApiErrors = errors };
                 }
 
                 // if we've got here then something unexpected has occured

--- a/Fitbit.Tests/UserTests.cs
+++ b/Fitbit.Tests/UserTests.cs
@@ -588,7 +588,7 @@ namespace Fibit.Tests
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Count == 1);
             ApiError error = result.First();
-            Assert.AreEqual(ErrorType.Request, error.ErrorType);
+            Assert.AreEqual("request", error.ErrorType);
             Assert.AreEqual("n/a", error.FieldName);
         }
     }


### PR DESCRIPTION
Added FluentAssertions to aid with testing of exceptions in the functions
Updated the tests so they can throw different exceptions.