### PR TITLE
Oauth2 automatic stale token detection, refresh, and single retry.

### DIFF
--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -132,6 +132,7 @@
     <None Include="SampleData\ActivityGoals.json" />
     <None Include="SampleData\AddSubscriptionResponse.json" />
     <None Include="SampleData\ApiError-Request-Forbidden.json" />
+    <None Include="SampleData\ApiError-Request-StaleToken.json" />
     <None Include="SampleData\ApiError-Request-Unauthorized.json" />
     <None Include="SampleData\ApiError-Request-BadRequest.json" />
     <None Include="SampleData\ApiSubscriptionNotification.json" />

--- a/Fitbit.Portable.Tests/FitbitClientHttpMessageHandlerTests.cs
+++ b/Fitbit.Portable.Tests/FitbitClientHttpMessageHandlerTests.cs
@@ -91,7 +91,7 @@
             //we shortcircuit the request to fake an expired token on the first request, and assuming the token is different the second time we let the request through
             var fakeServer = new StaleTokenFaker();
 
-            var sut = new FitbitClient(dummyCredentials, dummyToken, fakeServer, fakeManager.Object);
+            var sut = new FitbitClient(dummyCredentials, originalToken, fakeServer, fakeManager.Object);
 
             //Act
             var r = sut.HttpClient.GetAsync("https://dev.fitbit.com/");
@@ -99,8 +99,10 @@
             var actualResponse = r.Result;
 
             //Assert
-            fakeManager.Verify(m => m.RefreshToken(It.IsAny<FitbitClient>()), Times.Once);
             Assert.AreEqual(refreshedToken, sut.AccessToken);
+            //Ensure the client is updated with the refreshed token
+            Assert.AreEqual(refreshedToken.Token, sut.HttpClient.DefaultRequestHeaders.Authorization.Parameter);
+            fakeManager.Verify(m => m.RefreshToken(It.IsAny<FitbitClient>()), Times.Once);
         }
 
         public class StaleTokenFaker : IFitbitInterceptor

--- a/Fitbit.Portable.Tests/FitbitClientHttpMessageHandlerTests.cs
+++ b/Fitbit.Portable.Tests/FitbitClientHttpMessageHandlerTests.cs
@@ -103,12 +103,15 @@
             //Ensure the client is updated with the refreshed token
             Assert.AreEqual(refreshedToken.Token, sut.HttpClient.DefaultRequestHeaders.Authorization.Parameter);
             fakeManager.Verify(m => m.RefreshToken(It.IsAny<FitbitClient>()), Times.Once);
+            //Expecte two interceptions. First when we get the 401 refresh, and second when we retry after refreshing the stale token
+            Assert.AreEqual(2, fakeServer.requestCount, "It looks like either the client did not retry after the token was refreshed, or the stale token was not detected");
+
         }
 
         public class StaleTokenFaker : IFitbitInterceptor
         {
             HttpResponseMessage staleTokenresponse;
-            int requestCount = 0;
+            public int requestCount = 0;
 
             public StaleTokenFaker()
             {

--- a/Fitbit.Portable.Tests/FitbitClientHttpMessageHandlerTests.cs
+++ b/Fitbit.Portable.Tests/FitbitClientHttpMessageHandlerTests.cs
@@ -127,7 +127,7 @@
                     return null;
             }
 
-            public void InterceptResponse(HttpResponseMessage response, CancellationToken cancellationToken)
+            public async Task InterceptResponse(Task<HttpResponseMessage> response, CancellationToken cancellationToken)
             {
                 return;
             }

--- a/Fitbit.Portable.Tests/SampleData/ApiError-Request-StaleToken.json
+++ b/Fitbit.Portable.Tests/SampleData/ApiError-Request-StaleToken.json
@@ -1,0 +1,8 @@
+﻿{
+  "errors": [
+    {
+      "errorType": "expired_token",
+      "message": "Access token expired: eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0MzAzNDM3MzUsInNjb3BlcyI6Indwcm8gd2xvYyB3bnV0IHdzbGUgd3NldCB3aHIgd3dlaSB3YWN0IHdzb2MiLCJzdWIiOiJBQkNERUYiLCJhdWQiOiJJSktMTU4iLCJpc3MiOiJGaXRiaXQiLCJ0eXAiOiJhY2Nlc3NfdG9rZW4iLCJpYXQiOjE0MzAzNDAxMzV9.z0VHrIEzjsBnjiNMBey6wtu26yHTnSWz_qlqoEpUlpc"
+    }
+  ]
+}

--- a/Fitbit.Portable/FitBitHttpClientMessageHandler.cs
+++ b/Fitbit.Portable/FitBitHttpClientMessageHandler.cs
@@ -1,7 +1,12 @@
 ﻿namespace Fitbit.Api.Portable
 {
+    using Models;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -11,12 +16,15 @@
         private IFitbitInterceptor interceptor;
         Func<Task<HttpResponseMessage>, CancellationToken, Task<HttpResponseMessage>> responseHandler;
 
-        //private ITokenManager tokenManager;
+        public ITokenManager TokenManager { get; private set; }
 
-        public FitbitHttpClientMessageHandler(IFitbitInterceptor interceptor)
+        public FitbitClient Client { get; private set; }
+
+        public FitbitHttpClientMessageHandler(FitbitClient client, IFitbitInterceptor interceptor, ITokenManager tokenManager)
         {
+            this.Client = client;
             this.interceptor = interceptor;
-            //this.tokenManager = tokenManager;
+            this.TokenManager = tokenManager;
             responseHandler = ResponseHandler; 
             //Define the inner must handler. Otherwise exception is thrown.
             InnerHandler = new HttpClientHandler();
@@ -49,11 +57,52 @@
         //Handle the following method with EXTREME care as it will be invoked on ALL responses made by FitbitClient
         private async Task<HttpResponseMessage> ResponseHandler(Task<HttpResponseMessage> responseTask, CancellationToken cancellationToken)
         {
-            Debug.WriteLine("Entering Http client's response message handler. Response details: {0}", responseTask.Result);
+            DebugLogResponse(requestTask);
+
+            if (requestTask.Result.StatusCode == System.Net.HttpStatusCode.Unauthorized)//Unauthorized, then there is a chance token is stale
+            {
+                var responseBody = requestTask.Result.Content.ReadAsStringAsync().Result;
+
+                if (IsTokenStale(responseBody))
+                {
+                    Debug.WriteLine("Stale token detected. Invoking registered tokenManager.RefreskToken to refresh it");
+                    var RefreshedToken = TokenManager.RefreshToken(this.Client).Result;
+                    this.Client.AccessToken = RefreshedToken;
+                    //TO Do: either retry or notify client consumer that the called failed but it has been automatically retried
+                }
+            }
+
             if (interceptor != null)
                 await interceptor.InterceptResponse(responseTask, cancellationToken);
 
             return responseTask.Result;
+        }
+
+        private bool IsTokenStale(string responseBody)
+        {
+            JObject response = JObject.Parse(responseBody);
+            IList<JToken> errors = response["errors"].Children().ToList();
+
+            foreach (JToken error in errors)
+            {
+                var apiError = JsonConvert.DeserializeObject<ApiError>(error.ToString());
+                if (apiError.ErrorType == "expired_token")
+                    return true;
+            }
+
+            return false;
+        }
+
+        [Conditional("DEBUG")]
+        private static void DebugLogResponse(Task<HttpResponseMessage> requestTask)
+        {
+            string responseContent = null;
+
+            if (requestTask.Result.Content != null)
+                responseContent = requestTask.Result.Content.ReadAsStringAsync().Result;
+
+            Debug.WriteLine("Entering Http client's response message handler. Response details: \n {0}", requestTask.Result);
+            Debug.WriteLine("Response Content: \n {0}", responseContent ?? "Response body was empty");
         }
     }
 }

--- a/Fitbit.Portable/FitBitHttpClientMessageHandler.cs
+++ b/Fitbit.Portable/FitBitHttpClientMessageHandler.cs
@@ -65,7 +65,7 @@
             {
                 var responseBody = responseTask.Result.Content.ReadAsStringAsync().Result;
 
-                if (IsTokenStale(responseBody))
+                if (IsTokenStale(responseBody) && Client.EnableOAuth2TokenRefresh)
                 {
                     Debug.WriteLine("Stale token detected. Invoking registered tokenManager.RefreskToken to refresh it");
                     var RefreshedToken = TokenManager.RefreshToken(Client).Result;

--- a/Fitbit.Portable/FitBitHttpClientMessageHandler.cs
+++ b/Fitbit.Portable/FitBitHttpClientMessageHandler.cs
@@ -57,11 +57,11 @@
         //Handle the following method with EXTREME care as it will be invoked on ALL responses made by FitbitClient
         private async Task<HttpResponseMessage> ResponseHandler(Task<HttpResponseMessage> responseTask, CancellationToken cancellationToken)
         {
-            DebugLogResponse(requestTask);
+            DebugLogResponse(responseTask);
 
-            if (requestTask.Result.StatusCode == System.Net.HttpStatusCode.Unauthorized)//Unauthorized, then there is a chance token is stale
+            if (responseTask.Result.StatusCode == System.Net.HttpStatusCode.Unauthorized)//Unauthorized, then there is a chance token is stale
             {
-                var responseBody = requestTask.Result.Content.ReadAsStringAsync().Result;
+                var responseBody = responseTask.Result.Content.ReadAsStringAsync().Result;
 
                 if (IsTokenStale(responseBody))
                 {

--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="Authenticator.cs" />
     <Compile Include="FitbitAppCredentials.cs" />
+    <Compile Include="HttpRequestMessageExtensionMethods.cs" />
     <Compile Include="OAuth2\Authenticator2.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="FitbitClient.cs" />

--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -57,6 +57,8 @@
     <Compile Include="ITokenStore.cs" />
     <Compile Include="JsonDotNetSerializer.cs" />
     <Compile Include="JsonDotNetSerializerExtensions.cs" />
+    <Compile Include="OAuth2\DefaultTokenManager.cs" />
+    <Compile Include="OAuth2\ITokenManager.cs" />
     <Compile Include="OAuth2\OAuth2AccessToken.cs" />
     <Compile Include="OAuth2\OAuth2Helper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -38,6 +38,7 @@ namespace Fitbit.Api.Portable
         private IFitbitInterceptor MessageInterceptor { get; set; }
 
         public ITokenManager TokenManager { get; private set; }
+        public bool EnableOAuth2TokenRefresh { get; set; }
 
         /// <summary>
         /// Simplest constructor for OAuth2- requires the minimum information required by FitBit.Net client to make succesful calls to Fitbit Api
@@ -50,6 +51,7 @@ namespace Fitbit.Api.Portable
             this.AppCredentials = credentials;
             this.AccessToken = accessToken;
             this.MessageInterceptor = interceptor;
+            this.EnableOAuth2TokenRefresh = true;
 
             ConfigureTokenManager(tokenManager);
 
@@ -64,6 +66,8 @@ namespace Fitbit.Api.Portable
         /// <param name="interceptor">An interface that enables sniffing all outgoing and incoming http requests from FitbitClient</param>
         public FitbitClient(Func<HttpMessageHandler, HttpClient> customFactory, IFitbitInterceptor interceptor = null, ITokenManager tokenManager = null)
         {
+            this.EnableOAuth2TokenRefresh = false;
+
             ConfigureTokenManager(tokenManager);
             this.HttpClient = customFactory(new FitbitHttpClientMessageHandler(this, interceptor, this.TokenManager));
         }

--- a/Fitbit.Portable/HttpRequestMessageExtensionMethods.cs
+++ b/Fitbit.Portable/HttpRequestMessageExtensionMethods.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fitbit.Api.Portable
+{
+    internal static class HttpRequestMessageExtensionMethods
+    {
+        public static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage req)
+        {
+            HttpRequestMessage clone = new HttpRequestMessage(req.Method, req.RequestUri);
+
+            // Copy the request's content (via a MemoryStream) into the cloned object
+            var ms = new MemoryStream();
+            if (req.Content != null)
+            {
+                await req.Content.CopyToAsync(ms).ConfigureAwait(false);
+                ms.Position = 0;
+                clone.Content = new StreamContent(ms);
+
+                // Copy the content headers
+                if (req.Content.Headers != null)
+                    foreach (var h in req.Content.Headers)
+                        clone.Content.Headers.Add(h.Key, h.Value);
+            }
+
+
+            clone.Version = req.Version;
+
+            foreach (KeyValuePair<string, object> prop in req.Properties)
+                clone.Properties.Add(prop);
+
+            foreach (KeyValuePair<string, IEnumerable<string>> header in req.Headers)
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+            return clone;
+        }
+    }
+}

--- a/Fitbit.Portable/OAuth2/DefaultTokenManager.cs
+++ b/Fitbit.Portable/OAuth2/DefaultTokenManager.cs
@@ -1,0 +1,31 @@
+﻿namespace Fitbit.Api.Portable.OAuth2
+{
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    internal class DefaultTokenManager : ITokenManager
+    {
+        public async Task<OAuth2AccessToken> RefreshToken(FitbitClient client)
+        {
+            string postUrl = OAuth2Helper.FitbitOauthPostUrl;
+
+            var content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("grant_type", "refresh_token"),
+                new KeyValuePair<string, string>("refresh_token", client.AccessToken.RefreshToken),
+            });
+
+
+            var httpClient = new HttpClient();
+
+            var clientIdConcatSecret = OAuth2Helper.Base64Encode(client.AppCredentials.Value.ClientId + ":" + client.AppCredentials.Value.ClientSecret);
+            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", clientIdConcatSecret);
+
+            HttpResponseMessage response = await httpClient.PostAsync(postUrl, content);
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            return OAuth2Helper.ParseAccessTokenResponse(responseString);
+        }
+    }
+}

--- a/Fitbit.Portable/OAuth2/ITokenManager.cs
+++ b/Fitbit.Portable/OAuth2/ITokenManager.cs
@@ -1,0 +1,10 @@
+﻿using Fitbit.Api.Portable.OAuth2;
+using System.Threading.Tasks;
+
+namespace Fitbit.Api.Portable
+{
+    public interface ITokenManager
+    {
+        Task<OAuth2AccessToken> RefreshToken(FitbitClient client);
+    }
+}


### PR DESCRIPTION
`FitbitClient` now automatically detects if a token is stale. It calls provided implementation of [`ITokenManager`] (https://github.com/mxa0079/Fitbit.NET/blob/oauth2-autorefresh/Fitbit.Portable/OAuth2/ITokenManager.cs) to refresh token (the library provides a simple default implementation [`DefaultTokenManager`] (https://github.com/mxa0079/Fitbit.NET/blob/oauth2-autorefresh/Fitbit.Portable/OAuth2/DefaultTokenManager.cs)) and retries only ONCE to make the call with the refreshed token. If this second call fails, then the client throws.

You can see the full flow in this test: ['Correctly_Detects_Stale_Token_Refreshes_And_Retries_Original_Request' ] (https://github.com/mxa0079/Fitbit.NET/blob/oauth2-autorefresh/Fitbit.Portable.Tests/FitbitClientHttpMessageHandlerTests.cs#L82).

There is also the ability to [turn off the auto-token refresh behavior] (https://github.com/mxa0079/Fitbit.NET/blob/oauth2-autorefresh/Fitbit.Portable.Tests/FitbitClientHttpMessageHandlerTests.cs#L141).

Fixes #57  