### PR TITLE
Minor fixed to Portable.Tests project metadata

### DIFF
--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -111,7 +111,7 @@
     <Compile Include="DayActivityTests.cs" />
     <Compile Include="FatTests.cs" />
     <Compile Include="FitbitClientConstructorTests.cs" />
-    <Compile Include="FitbitClientExtensionsTests.cs" />
+    <Compile Include="FitbitClientHelperTests.cs" />
     <Compile Include="FitbitClientHelperExtensionsTests.cs" />
     <Compile Include="FitbitClientTests.cs" />
     <Compile Include="FoodTests.cs" />


### PR DESCRIPTION
Project file now references correct class name.