### PR TITLE
Making non-standard header use standard prefix

### DIFF
--- a/Fitbit.Portable/FitBitHttpClientMessageHandler.cs
+++ b/Fitbit.Portable/FitBitHttpClientMessageHandler.cs
@@ -75,7 +75,7 @@
                     if(!responseTask.Result.RequestMessage.Headers.Contains("Fitbit.Net-StaleTokenRetry"))
                     {
                         var clonedRequest = await responseTask.Result.RequestMessage.CloneAsync();
-                        clonedRequest.Headers.Add("Fitbit.Net-StaleTokenRetry", "Fitbit.Net-StaleTokenRetry");
+                        clonedRequest.Headers.Add("X-Fitbit.NET-StaleTokenRetry", "X-Fitbit.NET-StaleTokenRetry");
                         return await Client.HttpClient.SendAsync(clonedRequest, cancellationToken);
                     }
                     else if (responseTask.Result.RequestMessage.Headers.Contains("Fitbit.Net-StaleTokenRetry"))


### PR DESCRIPTION
In regards to:

Consistent none standard headers usually have the prefix "X-" eg
"X-Fitbit-Subscriber-Id". So we could add in
"X-Fitbit.NET-StaleTokenRetry"