### PR TITLE
Bringing consistency to the use of ApiCollectionType in the library

### DIFF
--- a/Fitbit.Portable.Tests/RemoveSubscriptionTests.cs
+++ b/Fitbit.Portable.Tests/RemoveSubscriptionTests.cs
@@ -24,7 +24,8 @@ namespace Fitbit.Portable.Tests
             var sut = this.SetupFitbitClient(null, expectedUrl, HttpMethod.Delete);
 
             //Any unexpected behavior will throw exception or fail on request checks (in handler)
-            sut.DeleteSubscriptionAsync(subId).Wait();
+            //Pass APICollectionType.user to delete subscriptions for all data sets
+            sut.DeleteSubscriptionAsync(subId, APICollectionType.user).Wait();
         }
 
         [Test]

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -831,12 +831,14 @@ namespace Fitbit.Api.Portable
             }
         }
 
-        public async Task DeleteSubscriptionAsync(string uniqueSubscriptionId, APICollectionType? collection = null, string subscriberId = null)
+        public async Task DeleteSubscriptionAsync(string uniqueSubscriptionId, APICollectionType collection, string subscriberId = null)
         {
             var collectionString = string.Empty;
 
-            if (collection != null)
-                collectionString = collection.Value.ToString() + @"/";
+            if (collection == APICollectionType.user)
+                collectionString = string.Empty;
+            else
+                collectionString = collection.ToString() + @"/";
 
             string url = "/1/user/-/{2}apiSubscriptions/{1}.json";
             string apiCall = FitbitClientHelperExtensions.ToFullUrl(url, args: new object[] {  uniqueSubscriptionId, collectionString });


### PR DESCRIPTION
Consumers need to specify APICollectionType.User to delete all subscriptions. Fix #56