### PR TITLE
Issue 155 - Fitbit error handler interceptor

### DIFF
--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -71,8 +71,9 @@
       <HintPath>..\Fitbit\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\Fitbit\packages\NUnit.2.6.0.12054\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\Fitbit\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>

--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Helper.cs" />
     <Compile Include="Helpers\ResponseFaker.cs" />
     <Compile Include="InterceptorCounter.cs" />
+    <Compile Include="Interceptors\FitbitHttpErrorHandlerTests.cs" />
     <Compile Include="IntradayTimeSeriesTests.cs" />
     <Compile Include="JsonDotNetSerializerTests.cs" />
     <Compile Include="Models\ActivitySummaryTests.cs" />

--- a/Fitbit.Portable.Tests/Interceptors/FitbitHttpErrorHandlerTests.cs
+++ b/Fitbit.Portable.Tests/Interceptors/FitbitHttpErrorHandlerTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fitbit.Api.Portable;
+using Fitbit.Api.Portable.Interceptors;
+using NUnit.Core;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Fitbit.Portable.Tests.Interceptors
+{
+    [TestFixture]
+    public class FitbitHttpErrorHandlerTests
+    {
+        Fixture fixture = new Fixture();
+
+        public FitbitHttpErrorHandlerTests()
+        {
+            fixture = new Fixture();
+
+            fixture.Customizations.Add(new TypeRelay(typeof(HttpContent), typeof(ByteArrayContent)));
+        }
+
+        //TO DO: Migrate to newer framework to move away from atribute base exception checking
+        [Test]
+        [ExpectedException(typeof(FitbitRequestException))]
+        public async void Throws_On_500()
+        {
+            var cancellationToken = new CancellationToken();
+            var unsuccesfulResponse =
+                fixture.Build<HttpResponseMessage>().With(r => r.StatusCode, HttpStatusCode.InternalServerError).Create();
+            var sut = fixture.Create<FitbitHttpErrorHandler>();
+
+            await sut.InterceptResponse(Task.FromResult(unsuccesfulResponse), cancellationToken, null);
+        }
+
+        //TO DO: Migrate to newer framework to move away from atribute base exception checking
+        [Test]
+        public async void Proceeds_On_200()
+        {
+            var cancellationToken = new CancellationToken();
+            var unsuccesfulResponse =
+                fixture.Build<HttpResponseMessage>().With(r => r.StatusCode, HttpStatusCode.OK).Create();
+            var sut = fixture.Create<FitbitHttpErrorHandler>();
+
+            var result = await sut.InterceptResponse(Task.FromResult(unsuccesfulResponse), cancellationToken, null);
+
+            //A null response means the interceptor is letting the pipeline continue its normal flow.
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/Fitbit.Portable.Tests/packages.config
+++ b/Fitbit.Portable.Tests/packages.config
@@ -8,6 +8,6 @@
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
-  <package id="NUnit" version="2.6.0.12054" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -39,6 +39,7 @@
     <Compile Include="FitbitHttpMessageHandler.cs" />
     <Compile Include="FitbitTokenException.cs" />
     <Compile Include="HttpRequestMessageExtensionMethods.cs" />
+    <Compile Include="Interceptors\FitbitHttpErrorHandler.cs" />
     <Compile Include="Models\ActivitiesStats.cs" />
     <Compile Include="Models\Activity.cs" />
     <Compile Include="Models\ActivityDistance.cs" />

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -769,7 +769,7 @@ namespace Fitbit.Api.Portable
                     case HttpStatusCode.Unauthorized:
                     case HttpStatusCode.Forbidden:
                     case HttpStatusCode.NotFound:
-                        throw new FitbitRequestException(response.StatusCode, errors);
+                        throw new FitbitRequestException(response, errors);
                 }
 
                 // if we've got here then something unexpected has occured

--- a/Fitbit.Portable/FitbitRequestException.cs
+++ b/Fitbit.Portable/FitbitRequestException.cs
@@ -1,17 +1,18 @@
 ﻿using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using Fitbit.Models;
 
 namespace Fitbit.Api.Portable
 {
     public class FitbitRequestException : FitbitException
     {
-        public HttpStatusCode StatusCode { get; set; }
+        public HttpResponseMessage Response { get; set; }
 
-        public FitbitRequestException(HttpStatusCode statusCode, IEnumerable<ApiError> errors)
-            : base($"Request exception - see errors for more details - {statusCode}", errors)
+        public FitbitRequestException(HttpResponseMessage response, IEnumerable<ApiError> errors)
+            : base($"Request exception - see errors for more details - {response.StatusCode}", errors)
         {
-            this.StatusCode = statusCode;
+            this.Response = response;
         }
     }
 }

--- a/Fitbit.Portable/Interceptors/FitbitHttpErrorHandler.cs
+++ b/Fitbit.Portable/Interceptors/FitbitHttpErrorHandler.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fitbit.Models;
+
+namespace Fitbit.Api.Portable.Interceptors
+{
+    public class FitbitHttpErrorHandler : IFitbitInterceptor
+    {
+        public Task<HttpResponseMessage> InterceptRequest(HttpRequestMessage request, CancellationToken cancellationToken, FitbitClient invokingClient)
+        {
+            return null;
+        }
+
+        public async Task<HttpResponseMessage> InterceptResponse(Task<HttpResponseMessage> response, CancellationToken cancellationToken, FitbitClient invokingClient)
+        {
+            if ((await response).IsSuccessStatusCode) return null;
+            else
+            {
+                await GenerateFitbitRequestException(await response);
+                return null;
+            }
+
+        }
+
+
+        private async Task GenerateFitbitRequestException(HttpResponseMessage response)
+        {
+            List<ApiError> errors = null;
+
+            try
+            {
+                // assumption is error response from fitbit in the 4xx range  
+                errors = new JsonDotNetSerializer().ParseErrors(await response.Content.ReadAsStringAsync());
+            }
+            catch(ArgumentNullException emptyBodyException)
+            {
+                errors = new List<ApiError>() { {new ApiError() {ErrorType = "Fitbit.Net client library error", Message = "Error parsing content body. The content was empty"} } };
+            }
+            catch (Exception e)
+            {
+                errors = new List<ApiError>() { { new ApiError() { ErrorType = "Fitbit.Net client library error", Message = "Unexpected error when deserializing the content of Fitbit's response." } } };
+            }
+
+            var exception = new FitbitRequestException(response, errors);
+
+            throw exception;                            
+        }
+    }
+}

--- a/Fitbit.Portable/JsonDotNetSerializer.cs
+++ b/Fitbit.Portable/JsonDotNetSerializer.cs
@@ -23,6 +23,7 @@ namespace Fitbit.Api.Portable
         {
             if (string.IsNullOrWhiteSpace(data))
             {
+                //TO DO: Is this the behavior we want? Or should we be throwing an exception?
                 return default(T);
             }
 


### PR DESCRIPTION
Fix #155

Simple check. Guarantees that FitbitClient will only get responses that are 200, otherwise throws a FitbitRequestException