### PR TITLE
Removed three warnings regarding unused exceptions

### DIFF
--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Models\Activity.cs" />
     <Compile Include="Models\ActivityDistance.cs" />
     <Compile Include="Models\ActivityGoals.cs" />
+    <Compile Include="Models\ActivityList.cs" />
     <Compile Include="Models\ActivityLog.cs" />
     <Compile Include="Models\ActivitySummary.cs" />
     <Compile Include="Models\APICollectionType.cs" />

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Fitbit.Api.Portable.OAuth2;
 using System.Net.Http.Headers;
+using Fitbit.Api.Portable.Models;
 using Fitbit.Models;
 
 namespace Fitbit.Api.Portable
@@ -842,6 +843,184 @@ namespace Fitbit.Api.Portable
                 var errors = new JsonDotNetSerializer().ParseErrors(await response.Content.ReadAsStringAsync());
                 throw new FitbitException("Unexpected response message", errors);
             }
+        }
+
+        /// <summary>
+        /// Logs the specified Activity item for the current logged in user - https://dev.fitbit.com/docs/activity/#activity-logging
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns>ActivityLog</returns>
+        public async Task<ActivityLog> LogActivityAsync(ActivityLog model)
+        {
+            string apiCall = FitbitClientHelperExtensions.ToFullUrl("/1/user/-/activities.json");
+
+            var items = new Dictionary<string, string>
+            {
+                {"activityId", model.ActivityId.ToString()},
+                {"manualCalories", model.Calories.ToString()},
+                {"startTime", model.StartTime},
+                {"durationMillis", model.Duration.ToString()},
+                {"date", DateTime.Now.ToFitbitFormat()},
+                {"distance", model.Distance.ToString()}
+            };
+
+            apiCall = $"{apiCall}?{string.Join("&", items.Select(x => $"{x.Key}={x.Value}"))}";
+
+            HttpResponseMessage response = await HttpClient.PostAsync(apiCall, new StringContent(string.Empty));
+            await HandleResponse(response);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return (new JsonDotNetSerializer() { RootProperty = "activityLog" }).Deserialize<ActivityLog>(responseBody);
+        }
+
+        /// <summary>
+        /// The Get Activity Logs List endpoint retrieves a list of a user's activity log entries before or after a given day with offset and limit using units in the unit system which corresponds to the Accept-Language header provided. - https://dev.fitbit.com/docs/activity/#get-activity-logs-list
+        /// </summary>
+        /// <param name="beforeDate">The date in the format yyyy-MM-ddTHH:mm:ss. Only yyyy-MM-dd is required. Either beforeDate or afterDate must be specified. Set sort to desc when using beforeDate.</param>
+        /// <param name="afterDate">The date in the format yyyy-MM-ddTHH:mm:ss. Only yyyy-MM-dd is required. Either beforeDate or afterDate must be specified. Set sort to asc when using afterDate.</param>
+        /// <param name="limit">The max of the number of entries returned (maximum: 20)</param>
+        /// <param name="encodedUserId">encoded user id, can be null for current logged in user</param>
+        /// <returns>ActivityLog</returns>
+        public async Task<List<ActivityList>> GetActivityLogsList(DateTime? beforeDate, DateTime? afterDate, int limit = 20, string encodedUserId = default(string))
+        {
+            var apiCall = string.Empty;
+            limit = limit > 20 ? 20 : limit;
+            const int offset = 0;
+            var sort = string.Empty;
+            var dateString = string.Empty;
+            var date = string.Empty;
+
+            if (beforeDate != null && afterDate != null)
+            {
+                throw new ArgumentException("Please only specify a beforeDate or afterDate, not both: https://dev.fitbit.com/docs/activity/#get-activity-logs-list");
+            }
+
+            if (beforeDate != null)
+            {
+                dateString = "beforeDate";
+                date = beforeDate.Value.ToString("yyyy-MM-ddTHH:mm:ss");
+                sort = "desc";
+            }
+            if (afterDate != null)
+            {
+                dateString = "afterDate";
+                date = afterDate.Value.ToString("yyyy-MM-ddTHH:mm:ss");
+                sort = "asc";
+            }
+
+            apiCall = FitbitClientHelperExtensions.ToFullUrl("/1/user/{0}/activities/list.json?{1}={2}&sort={3}&limit={4}&offset={5}", encodedUserId, dateString, date, sort, limit, offset);
+
+            HttpResponseMessage response = await HttpClient.GetAsync(apiCall);
+            await HandleResponse(response);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return (new JsonDotNetSerializer() { RootProperty = "activities" }).Deserialize<List<ActivityList>>(responseBody);
+        }
+
+        /// <summary>
+        /// The Get Heart Rate Time Series endpoint returns time series data in the specified range for a given resource in the format requested using units in the unit systems that corresponds to the Accept-Language header provided. - https://dev.fitbit.com/docs/heart-rate/#get-heart-rate-time-series
+        /// </summary>
+        /// <param name="date">The end date of the period specified in the format yyyy-MM-dd or today.</param>
+        /// <param name="period">The range for which data will be returned. Options are 1d, 7d, 30d, 1w, 1m.</param>
+        /// <param name="encodedUserId">encoded user id, can be null for current logged in user</param>
+        /// <returns>List of HeartActivitiesTimeSeries</returns>
+        public async Task<List<HeartActivitiesTimeSeries>> GetHeartRateTimeSeries(string date, string period, string encodedUserId = default(string))
+        {
+            string apiCall = FitbitClientHelperExtensions.ToFullUrl("/1/user/{0}/activities/heart/date/{1}/{2}.json", encodedUserId, date, period);
+
+            HttpResponseMessage response = await HttpClient.GetAsync(apiCall);
+            await HandleResponse(response);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return (new JsonDotNetSerializer() { RootProperty = "activities-heart" }).Deserialize<List<HeartActivitiesTimeSeries>>(responseBody);
+        }
+
+        /// <summary>
+        /// The Get Heart Rate Time Series endpoint returns time series data in the specified range for a given resource in the format requested using units in the unit systems that corresponds to the Accept-Language header provided. - https://dev.fitbit.com/docs/heart-rate/#get-heart-rate-time-series
+        /// </summary>
+        /// <param name="baseDate">The range start date, in the format yyyy-MM-dd or today.</param>
+        /// <param name="endDate">The end date of the range.</param>
+        /// <param name="encodedUserId">encoded user id, can be null for current logged in user</param>
+        /// <returns>List of HeartActivitiesTimeSeries</returns>
+        public async Task<List<HeartActivitiesTimeSeries>> GetHeartRateTimeSeries(string baseDate, DateTime endDate, string encodedUserId = default(string))
+        {
+            string apiCall = FitbitClientHelperExtensions.ToFullUrl("/1/user/{0}/activities/heart/date/{1}/{2}.json", encodedUserId, baseDate, endDate.ToFitbitFormat());
+
+            HttpResponseMessage response = await HttpClient.GetAsync(apiCall);
+            await HandleResponse(response);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return (new JsonDotNetSerializer() { RootProperty = "activities-heart" }).Deserialize<List<HeartActivitiesTimeSeries>>(responseBody);
+        }
+
+        /// <summary>
+        /// The Get Heart Rate Intraday Time Series endpoint returns the intraday time series for a given resource in the format requested. - https://dev.fitbit.com/docs/heart-rate/#get-heart-rate-intraday-time-series
+        /// </summary>
+        /// <param name="date">The date, in the format yyyy-MM-dd or today.</param>
+        /// <param name="endDate">The end date of the range.</param>
+        /// <param name="detailLevel">Number of data points to include. Either 1sec or 1min.</param>
+        /// <param name="encodedUserId">encoded user id, can be null for current logged in user</param>
+        /// <returns>List of HeartActivitiesIntraday</returns>
+        public async Task<HeartActivitiesIntraday> GetHeartRateIntradayTimeSeries(string date, DateTime endDate, string detailLevel, string encodedUserId = default(string))
+        {
+            string apiCall = FitbitClientHelperExtensions.ToFullUrl("/1/user/{0}/activities/heart/date/{1}/{2}/{3}.json", encodedUserId, date, endDate.ToFitbitFormat(), detailLevel);
+
+            HttpResponseMessage response = await HttpClient.GetAsync(apiCall);
+            await HandleResponse(response);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return (new JsonDotNetSerializer() { RootProperty = "activities-heart-intraday" }).Deserialize<HeartActivitiesIntraday>(responseBody);
+        }
+
+        /// <summary>
+        /// The Get Heart Rate Intraday Time Series endpoint returns the intraday time series for a given resource in the format requested. - https://dev.fitbit.com/docs/heart-rate/#get-heart-rate-intraday-time-series
+        /// </summary>
+        /// <param name="date">The date, in the format yyyy-MM-dd or today.</param>
+        /// <param name="endDate">The end date of the range.</param>
+        /// <param name="detailLevel">Number of data points to include. Either 1sec or 1min.</param>
+        /// <param name="startTime">The start of the period, in the format HH:mm.</param>
+        /// <param name="endTime">The end of the period, in the format HH:mm.</param>
+        /// <param name="encodedUserId">encoded user id, can be null for current logged in user</param>
+        /// <returns>List of HeartActivitiesIntraday</returns>
+        public async Task<HeartActivitiesIntraday> GetHeartRateIntradayTimeSeries(string date, DateTime endDate, string detailLevel, TimeSpan startTime, TimeSpan endTime, string encodedUserId = default(string))
+        {
+            string apiCall = FitbitClientHelperExtensions.ToFullUrl("/1/user/{0}/activities/heart/date/{1}/{2}/{3}/time/{4}/{5}.json", encodedUserId, date, endDate.ToFitbitFormat(), detailLevel, startTime.ToString("HH:mm"), endTime.ToString("HH:mm"));
+
+            HttpResponseMessage response = await HttpClient.GetAsync(apiCall);
+            await HandleResponse(response);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return (new JsonDotNetSerializer() { RootProperty = "activities-heart-intraday" }).Deserialize<HeartActivitiesIntraday>(responseBody);
+        }
+
+        /// <summary>
+        /// The Get Heart Rate Intraday Time Series endpoint returns the intraday time series for a given resource in the format requested. - https://dev.fitbit.com/docs/heart-rate/#get-heart-rate-intraday-time-series
+        /// </summary>
+        /// <param name="date">The date, in the format yyyy-MM-dd or today.</param>
+        /// <param name="detailLevel">Number of data points to include. Either 1sec or 1min.</param>
+        /// <param name="encodedUserId">encoded user id, can be null for current logged in user</param>
+        /// <returns>List of HeartActivitiesIntraday</returns>
+        public async Task<HeartActivitiesIntraday> GetHeartRateIntradayTimeSeries(string date, string detailLevel, string encodedUserId = default(string))
+        {
+            string apiCall = FitbitClientHelperExtensions.ToFullUrl("/1/user/{0}/activities/heart/date/{1}/1d/{2}.json", encodedUserId, date, detailLevel);
+
+            HttpResponseMessage response = await HttpClient.GetAsync(apiCall);
+            await HandleResponse(response);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return (new JsonDotNetSerializer() { RootProperty = "activities-heart-intraday" }).Deserialize<HeartActivitiesIntraday>(responseBody);
+        }
+
+        /// <summary>
+        /// The Get Heart Rate Intraday Time Series endpoint returns the intraday time series for a given resource in the format requested. - https://dev.fitbit.com/docs/heart-rate/#get-heart-rate-intraday-time-series
+        /// </summary>
+        /// <param name="date">The date, in the format yyyy-MM-dd or today.</param>
+        /// <param name="detailLevel">Number of data points to include. Either 1sec or 1min.</param>
+        /// <param name="startTime">The start of the period, in the format HH:mm.</param>
+        /// <param name="endTime">The end of the period, in the format HH:mm.</param>
+        /// <param name="encodedUserId">encoded user id, can be null for current logged in user</param>
+        /// <returns>List of HeartActivitiesIntraday</returns>
+        public async Task<HeartActivitiesIntraday> GetHeartRateIntradayTimeSeries(string date, string detailLevel, TimeSpan startTime, TimeSpan endTime, string encodedUserId = default(string))
+        {
+            string apiCall = FitbitClientHelperExtensions.ToFullUrl("/1/user/{0}/activities/heart/date/{1}/1d/{2}/time/{3}/{4}.json", encodedUserId, date, detailLevel, startTime.ToString("HH:mm"), endTime.ToString("HH:mm"));
+
+            HttpResponseMessage response = await HttpClient.GetAsync(apiCall);
+            await HandleResponse(response);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return (new JsonDotNetSerializer() { RootProperty = "activities-heart-intraday" }).Deserialize<HeartActivitiesIntraday>(responseBody);
         }
 
         private string FormatKey(APICollectionType apiCollectionType, string format)

--- a/Fitbit.Portable/IFitbitClient.cs
+++ b/Fitbit.Portable/IFitbitClient.cs
@@ -30,9 +30,22 @@ namespace Fitbit.Api.Portable
         Task<WaterData> GetWaterAsync(DateTime date);
         Task<WaterLog> LogWaterAsync(DateTime date, WaterLog log);
         Task DeleteWaterLogAsync(long logId);
-
         Task<List<ApiSubscription>> GetSubscriptionsAsync();
         Task<ApiSubscription> AddSubscriptionAsync(APICollectionType apiCollectionType, string uniqueSubscriptionId, string subscriberId = default(string));
         Task DeleteSubscriptionAsync(APICollectionType collection, string uniqueSubscriptionId, string subscriberId = null);
+        Task<ActivityLog> LogActivityAsync(ActivityLog model);
+        Task<List<HeartActivitiesTimeSeries>> GetHeartRateTimeSeries(string date, string period,
+            string encodedUserId = default(string));
+        Task<List<HeartActivitiesTimeSeries>> GetHeartRateTimeSeries(string baseDate, DateTime endDate,
+            string encodedUserId = default(string));
+        Task<HeartActivitiesIntraday> GetHeartRateIntradayTimeSeries(string date, DateTime endDate, string detailLevel,
+            string encodedUserId = default(string));
+        Task<HeartActivitiesIntraday> GetHeartRateIntradayTimeSeries(string date, DateTime endDate, string detailLevel,
+            TimeSpan startTime, TimeSpan endTime, string encodedUserId = default(string));
+        Task<HeartActivitiesIntraday> GetHeartRateIntradayTimeSeries(string date, string detailLevel,
+            string encodedUserId = default(string));
+        Task<HeartActivitiesIntraday> GetHeartRateIntradayTimeSeries(string date, string detailLevel, TimeSpan startTime,
+            TimeSpan endTime, string encodedUserId = default(string));
+        Task<List<ActivityList>> GetActivityLogsList(DateTime? beforeDate, DateTime? afterDate, int limit = 20, string encodedUserId = default(string));
     }
 }

--- a/Fitbit.Portable/Interceptors/FitbitHttpErrorHandler.cs
+++ b/Fitbit.Portable/Interceptors/FitbitHttpErrorHandler.cs
@@ -38,11 +38,11 @@ namespace Fitbit.Api.Portable.Interceptors
                 // assumption is error response from fitbit in the 4xx range  
                 errors = new JsonDotNetSerializer().ParseErrors(await response.Content.ReadAsStringAsync());
             }
-            catch(ArgumentNullException emptyBodyException)
+            catch(ArgumentNullException)
             {
                 errors = new List<ApiError>() { {new ApiError() {ErrorType = "Fitbit.Net client library error", Message = "Error parsing content body. The content was empty"} } };
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 errors = new List<ApiError>() { { new ApiError() { ErrorType = "Fitbit.Net client library error", Message = "Unexpected error when deserializing the content of Fitbit's response." } } };
             }

--- a/Fitbit.Portable/JsonDotNetSerializerExtensions.cs
+++ b/Fitbit.Portable/JsonDotNetSerializerExtensions.cs
@@ -219,7 +219,7 @@ namespace Fitbit.Api.Portable
             {
                 date = parsedJToken.SelectToken(serializer.RootProperty).First["dateTime"];
             }
-            catch (NullReferenceException nullReferenceException)
+            catch (NullReferenceException)
             {
                 //We'll nullref here if we're querying a future date - Fitbit omits dateTime in that case.
                 //Return null since this error will, in all cases, coincide with an otherwise empty (all zeros) object

--- a/Fitbit.Portable/Models/ActivityList.cs
+++ b/Fitbit.Portable/Models/ActivityList.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Fitbit.Models
+{
+    public class ActivityList
+    {
+        [JsonProperty(PropertyName = "activeDuration")]
+        public double ActiveDuration { get; set; }
+
+        [JsonProperty(PropertyName = "activityLevel")]
+        public List<ActivityLevel> ActivityLevel { get; set; }
+
+        [JsonProperty(PropertyName = "activityName")]
+        public string ActivityName { get; set; }
+
+        [JsonProperty(PropertyName = "activityTypeId")]
+        public double ActivityTypeId { get; set; }
+        
+        //public int averageHeartRate { get; set; }
+
+        [JsonProperty(PropertyName = "calories")]
+        public double Calories { get; set; }
+        
+        //public string caloriesLink { get; set; }
+
+        [JsonProperty(PropertyName = "distance")]
+        public double Distance { get; set; }
+
+        [JsonProperty(PropertyName = "distanceUnit")]
+        public string DistanceUnit { get; set; }
+
+        [JsonProperty(PropertyName = "duration")]
+        public double Duration { get; set; }
+        
+        //public string heartRateLink { get; set; }
+
+        [JsonProperty(PropertyName = "lastModified")]
+        public DateTime LastModified { get; set; }
+
+        [JsonProperty(PropertyName = "logId")]
+        public double LogId { get; set; }
+
+        [JsonProperty(PropertyName = "logType")]
+        public string LogType { get; set; }
+
+        [JsonProperty(PropertyName = "manualValuesSpecified")]
+        public ManualValuesSpecified ManualValuesSpecified { get; set; }
+
+        [JsonProperty(PropertyName = "originalDuration")]
+        public double OriginalDuration { get; set; }
+
+        [JsonProperty(PropertyName = "originalStartTime")]
+        public DateTime OriginalStartTime { get; set; }
+
+        [JsonProperty(PropertyName = "source")]
+        public Source Source { get; set; }
+
+        [JsonProperty(PropertyName = "speed")]
+        public double Speed { get; set; }
+
+        [JsonProperty(PropertyName = "startTime")]
+        public DateTime StartTime { get; set; }
+        
+        //public int steps { get; set; }
+        //public List<HeartRateZone> heartRateZones { get; set; }
+
+        [JsonProperty(PropertyName = "tcxLink")]
+        public string TcxLink { get; set; }
+    }
+
+    public class ActivityLevel
+    {
+        [JsonProperty(PropertyName = "minutes")]
+        public double Minutes { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+    }
+
+    //public class HeartRateZone
+    //{
+    //    public int max { get; set; }
+    //    public int min { get; set; }
+    //    public int minutes { get; set; }
+    //    public string name { get; set; }
+    //}
+
+    public class ManualValuesSpecified
+    {
+        [JsonProperty(PropertyName = "calories")]
+        public bool Calories { get; set; }
+
+        [JsonProperty(PropertyName = "distance")]
+        public bool Distance { get; set; }
+
+        [JsonProperty(PropertyName = "steps")]
+        public bool Steps { get; set; }
+    }
+
+    public class Source
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+
+        [JsonProperty(PropertyName = "url")]
+        public string Url { get; set; }
+    }
+}

--- a/Fitbit.Portable/Models/HeartActivitiesIntraday.cs
+++ b/Fitbit.Portable/Models/HeartActivitiesIntraday.cs
@@ -1,129 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Fitbit.Models
 {
-    //[JsonConverter(typeof(HeartActivitiesIntradayConverter))]
     public class HeartActivitiesIntraday
     {
+        [JsonProperty(PropertyName = "dataset")]
         public List<DatasetInterval> Dataset { get; set; }
 
+        [JsonProperty(PropertyName = "datasetInterval")]
         public int DatasetInterval { get; set; }
+
+        [JsonProperty(PropertyName = "datasetType")]
         public string DatasetType { get; set; }
     }
 
-    //[JsonConverter(typeof(DatasetIntervalConverter))]
     public class DatasetInterval
     {
+        [JsonProperty(PropertyName = "time")]
         public DateTime Time { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
         public int Value { get; set;}
     }
-
-    public class HeartActivitiesIntradayConverter : JsonConverter
-    {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            var heartActivitiesIntraday = value as HeartActivitiesIntraday;
-
-            //{
-            writer.WriteStartObject();
-
-            // "DatasetInterval" : "1"
-            writer.WritePropertyName("DatasetInterval");
-            writer.WriteValue(heartActivitiesIntraday.DatasetInterval);
-
-            // "DatasetType" : "SecondsHeartrate"
-            writer.WritePropertyName("DatasetType");
-            writer.WriteValue(heartActivitiesIntraday.DatasetType);
-
-            writer.WritePropertyName("Dataset");
-            writer.WriteStartArray();
-            foreach (var datasetInverval in heartActivitiesIntraday.Dataset)
-            {
-                // "Time" : "2008-09-22T14:01:54.9571247Z"
-                writer.WritePropertyName("Time");
-                writer.WriteValue(datasetInverval.Time.ToString("o"));
-
-                // "Value": 1
-                writer.WritePropertyName("Value");
-                writer.WriteValue(datasetInverval.Value);
-
-            }
-            writer.WriteEndArray();
-            
-            //}
-            writer.WriteEndObject();
-
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            JObject jsonObject = JObject.Load(reader);
-            var properties = jsonObject.Properties().ToList();
-
-            HeartActivitiesIntraday result = new HeartActivitiesIntraday();
-            result.DatasetInterval = Convert.ToInt32(jsonObject["DatasetInterval"]);
-            result.DatasetType = jsonObject["DatasetType"].ToString();
-            result.Dataset = new List<DatasetInterval>();
-
-            foreach(JToken item in jsonObject["Dataset"].Children())
-            {
-                result.Dataset.Add(new DatasetInterval()
-                {
-                    Time = DateTime.Parse(item["Time"].ToString()),
-                    Value = Convert.ToInt32(item["Value"])
-                });
-            };
-
-            return result;
-        }
-
-        public override bool CanConvert(Type objectType)
-        {
-            return typeof(HeartActivitiesIntraday).IsAssignableFrom(objectType);
-        }
-    }
-
-    /*
-    public class DatasetIntervalConverter : JsonConverter
-    {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {            
-            var datasetInverval = value as DatasetInterval;
-
-            //{
-            writer.WriteStartObject();
-
-            // "Time" : "2008-09-22T14:01:54.9571247Z"
-            writer.WritePropertyName("Time");
-            writer.WriteValue(datasetInverval.Time.ToString("o"));
-            
-            // "Value": 1
-            writer.WritePropertyName("Value");
-            writer.WriteValue(datasetInverval.Value);
-            
-            //}
-            writer.WriteEndObject();
-
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            JObject jsonObject = JObject.Load(reader);
-            var properties = jsonObject.Properties().ToList();
-            return new DatasetInterval
-            {
-                Time = DateTime.Parse(jsonObject["Time"].ToString()),
-                Value = Convert.ToInt32(jsonObject["Value"])
-            };
-        }
-
-        public override bool CanConvert(Type objectType)
-        {
-            return typeof(DatasetInterval).IsAssignableFrom(objectType);
-        }
-    } */
 }

--- a/Fitbit.Portable/Models/HeartActivitiesTimeSeries.cs
+++ b/Fitbit.Portable/Models/HeartActivitiesTimeSeries.cs
@@ -1,9 +1,28 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Fitbit.Models
 {
     public class HeartActivitiesTimeSeries
     {
-        public List<HeartActivities> HeartActivities { get; set; }
+        [JsonProperty(PropertyName = "dateTime")]
+        public DateTime DateTime { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public Value Value { get; set; }
     }
+
+    public class Value
+    {
+        [JsonProperty(PropertyName = "customHeartRateZones")]
+        public List<object> CustomHeartRateZones { get; set; }
+
+        [JsonProperty(PropertyName = "heartRateZones")]
+        public List<HeartRateZone> HeartRateZones { get; set; }
+
+        [JsonProperty(PropertyName = "restingHeartRate")]
+        public int RestingHeartRate { get; set; }
+    }
+
 }

--- a/Fitbit.Portable/Models/HeartRateZone.cs
+++ b/Fitbit.Portable/Models/HeartRateZone.cs
@@ -1,11 +1,22 @@
-﻿namespace Fitbit.Models
+﻿using Newtonsoft.Json;
+
+namespace Fitbit.Models
 {
     public class HeartRateZone
     {
+        [JsonProperty(PropertyName = "caloriesOut")]
         public float CaloriesOut { get; set; }
+
+        [JsonProperty(PropertyName = "max")]
         public int Max { get; set; }
+
+        [JsonProperty(PropertyName = "min")]
         public int Min { get; set; }
+
+        [JsonProperty(PropertyName = "minutes")]
         public int Minutes { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
     }
 }


### PR DESCRIPTION
If you have "catch (Exception e)" and never use 'e' you'll get a
compiler warning. Turning this warning off globally is probably not the best
solution. Replacing with "catch (Exception) with no variable name
removes this warning.