### PR TITLE
add heart rate methods to IFitBitClient interface

### DIFF
--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -137,7 +137,7 @@ namespace Fitbit.Api.Portable
         private void ConfigureTokenManager(ITokenManager tokenManager)
         {
             TokenManager = tokenManager ?? new DefaultTokenManager();
-            }
+        }
 
         private void CreateHttpClientForOAuth2()
         {
@@ -386,8 +386,6 @@ namespace Fitbit.Api.Portable
             return serializer.GetFriends(responseBody);
         }
 
-
-
         /// <summary>
         /// Request to get heart rate in specific in a range time
         /// </summary>
@@ -414,7 +412,6 @@ namespace Fitbit.Api.Portable
 
             return fitbitResponse;
         }
-
 
         /// <summary>
         /// Request to get heart rate in a day
@@ -444,11 +441,6 @@ namespace Fitbit.Api.Portable
 
             return seralizer.GetHeartRateIntraday(date, responseBody);
         }
-
-
-
-
-
 
         /// <summary>
         /// Requests the user profile of the encoded user id or if none specified the current logged in user

--- a/Fitbit.Portable/IFitbitClient.cs
+++ b/Fitbit.Portable/IFitbitClient.cs
@@ -18,6 +18,8 @@ namespace Fitbit.Api.Portable
         Task<SleepLogDateRange> PostLogSleepAsync(string startTime, int duration, DateTime date, string encodedUserId = default(string));
         Task<List<Device>> GetDevicesAsync();
         Task<List<UserProfile>> GetFriendsAsync(string encodedUserId = default(string));
+        Task<HeartActivitiesTimeSeries> GetHeartRateTimeSeries(DateTime date, DateRangePeriod dateRangePeriod, string userId = null);
+        Task<HeartActivitiesIntraday> GetHeartRateIntraday(DateTime date, HeartRateResolution resolution);
         Task<UserProfile> GetUserProfileAsync(string encodedUserId = default(string));
         Task<TimeSeriesDataList> GetTimeSeriesAsync(TimeSeriesResourceType timeSeriesResourceType, DateTime startDate, DateTime endDate, string encodedUserId = default(string));
         Task<TimeSeriesDataList> GetTimeSeriesAsync(TimeSeriesResourceType timeSeriesResourceType, DateTime endDate, DateRangePeriod period, string encodedUserId = default(string));


### PR DESCRIPTION
`GetHeartRateTimeSeries` and `GetHeartRateIntraday` were previously added to `FitbitClient`, but were not added to the interface `IFitbitClient`. This PR adds these methods to the interface.