### PR TITLE
Add .Net Core support

### DIFF
--- a/Fitbit.NetCore.Tests/App.config
+++ b/Fitbit.NetCore.Tests/App.config
@@ -1,10 +1,10 @@
-﻿<configuration>
+<configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="4.1.1.0-4.1.1.1" newVersion="4.1.1.1" />
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="4.1.1.0-4.1.1.1" newVersion="4.1.1.1"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>

--- a/Fitbit.NetCore.Tests/App.config
+++ b/Fitbit.NetCore.Tests/App.config
@@ -1,0 +1,10 @@
+﻿<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="4.1.1.0-4.1.1.1" newVersion="4.1.1.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Fitbit.NetCore.Tests/Fitbit.NetCore.Tests.csproj
+++ b/Fitbit.NetCore.Tests/Fitbit.NetCore.Tests.csproj
@@ -97,7 +97,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
- 
+
+  <!-- When testing, we want to use the .NET Standard 1.3 asset and not the 4.5 one -->
+  <PropertyGroup>
+    <ReferringTargetFrameworkForProjectReferences>netstandard1.3</ReferringTargetFrameworkForProjectReferences>
+  </PropertyGroup>
+  
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />

--- a/Fitbit.NetCore.Tests/Fitbit.NetCore.Tests.csproj
+++ b/Fitbit.NetCore.Tests/Fitbit.NetCore.Tests.csproj
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Fitbit\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\Fitbit\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DE9D7F3C-6F6C-43E2-AEE6-32E7DF894F3E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Fitbit.NetCore.Tests</RootNamespace>
+    <AssemblyName>Fitbit.NetCore.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.7.99.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Moq.4.7.99\lib\net45\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\AutoFixture.3.50.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\System.Net.Http.4.3.2\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add all the tests except the FitbitReponseTests which are not used -->
+    <Compile Include="..\Fitbit.Portable.Tests\**\*.cs" Exclude="..\Fitbit.Portable.Tests\**\FitbitResponseTests.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+
+    <!-- Add the sample data files-->
+    <None Include="..\Fitbit.Portable.Tests\**\*.xml">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+
+    <None Include="..\Fitbit.Portable.Tests\**\*.json">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+ 
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Fitbit.NetCore\Fitbit.NetCore.csproj">
+      <Project>{81f4f528-0e81-49e0-a2b2-ed77495a9c15}</Project>
+      <Name>Fitbit.NetCore</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\Fitbit\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\Fitbit\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
+</Project>

--- a/Fitbit.NetCore.Tests/packages.config
+++ b/Fitbit.NetCore.Tests/packages.config
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AutoFixture" version="3.50.3" targetFramework="net46" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net46" />
+  <package id="FluentAssertions" version="4.19.3" targetFramework="net46" />
+  <package id="Moq" version="4.7.99" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
+  <package id="NUnit" version="3.7.1" targetFramework="net46" />
+  <package id="NUnit.Console" version="3.7.0" targetFramework="net46" />
+  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net46" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net46" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net46" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net46" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net46" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net46" />
+  <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net46" />
+  <package id="System.Net.Http" version="4.3.2" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
+</packages>

--- a/Fitbit.NetCore/AssemblyInfo.cs
+++ b/Fitbit.NetCore/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Fitbit.NetCore")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Fitbit API client for .NET")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Fitbit.Portable")]

--- a/Fitbit.NetCore/AssemblyInfo.cs
+++ b/Fitbit.NetCore/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+﻿using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Fitbit.NetCore")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Fitbit.Portable")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("Fitbit.NetCore.Tests")]

--- a/Fitbit.NetCore/Fitbit.NetCore.csproj
+++ b/Fitbit.NetCore/Fitbit.NetCore.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <DefineConstants>DEBUG;NETSTANDARD_13</DefineConstants>
+    <Configurations>Debug;Release</Configurations>
+    <Platforms>AnyCPU</Platforms>
+    <AssemblyName>Fitbit</AssemblyName>
+    <RootNamespace>Fitbit</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Fitbit.Portable\**\*.cs" Exclude="..\Fitbit.Portable\**\AssemblyInfo.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Class1.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/Fitbit.NetCore/Fitbit.NetCore.csproj
+++ b/Fitbit.NetCore/Fitbit.NetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>DEBUG;NETSTANDARD1_3</DefineConstants>
     <Configurations>Debug;Release</Configurations>
@@ -18,7 +18,14 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/Fitbit.NetCore/Fitbit.NetCore.csproj
+++ b/Fitbit.NetCore/Fitbit.NetCore.csproj
@@ -8,6 +8,15 @@
     <Platforms>AnyCPU</Platforms>
     <AssemblyName>Fitbit</AssemblyName>
     <RootNamespace>Fitbit</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Fitbit.NET</PackageId>
+    <PackageVersion>3.0.0</PackageVersion>
+    <Authors>Fitbit.Net contributors Team -- @WestDiscGolf, @aarondcoleman, @mxa0079, @joshFitabase</Authors>
+    <PackageLicenseUrl>https://github.com/aarondcoleman/Fitbit.NET</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/aarondcoleman/Fitbit.NET</PackageProjectUrl>
+    <PackageIconUrl>http://static3.fitbit.com/simple.b-dis-png.h76d53d8e6a0653b38326a825b2b9cf57.pack?items=%2Fimages%2Fcommon%2Fbg_branding_b.png</PackageIconUrl>
+    <PackageTags>Fitbit OAuth2 API .NET IoT Wearables</PackageTags>
+    <PackageOutputPath>..\NuGet</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fitbit.NetCore/Fitbit.NetCore.csproj
+++ b/Fitbit.NetCore/Fitbit.NetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DefineConstants>DEBUG;NETSTANDARD_13</DefineConstants>
+    <DefineConstants>DEBUG;NETSTANDARD1_3</DefineConstants>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
     <AssemblyName>Fitbit</AssemblyName>
@@ -14,10 +14,6 @@
     <Compile Include="..\Fitbit.Portable\**\*.cs" Exclude="..\Fitbit.Portable\**\AssemblyInfo.cs">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Class1.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fitbit.NetCore/NuGet.config
+++ b/Fitbit.NetCore/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Fitbit.NetCore/NuGet.config
+++ b/Fitbit.NetCore/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Fitbit.Portable.Tests/ActivitiesStatsTests.cs
+++ b/Fitbit.Portable.Tests/ActivitiesStatsTests.cs
@@ -6,6 +6,7 @@ using Fitbit.Api.Portable;
 using Fitbit.Models;
 using FluentAssertions;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace Fitbit.Portable.Tests
 {
@@ -13,7 +14,7 @@ namespace Fitbit.Portable.Tests
     {
         [Test]
         [Category("Portable")]
-        public async void GetActivityStatsAsync_Success()
+        public async Task GetActivityStatsAsync_Success()
         {
             string content = SampleDataHelper.GetContent("ActivitiesStats.json");
 

--- a/Fitbit.Portable.Tests/AddSubscriptionTests.cs
+++ b/Fitbit.Portable.Tests/AddSubscriptionTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace Fitbit.Portable.Tests
 {
@@ -26,7 +27,7 @@ namespace Fitbit.Portable.Tests
         [Test]
         [Category("PubSub")]
         [Category("Portable")]
-        public async void AddSubscription_UserEndPoint_WithoutSubscriberId()
+        public async Task AddSubscription_UserEndPoint_WithoutSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -42,7 +43,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_UserEndPoint_WithSubscriberId()
+        public async Task AddSubscription_UserEndPoint_WithSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -64,7 +65,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_ActivitiesEndPoint_WithoutSubscriberId()
+        public async Task AddSubscription_ActivitiesEndPoint_WithoutSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -80,7 +81,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_ActivitiesEndPoint_WithSubscriberId()
+        public async Task AddSubscription_ActivitiesEndPoint_WithSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -102,7 +103,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_BodyEndPoint_WithoutSubscriberId()
+        public async Task AddSubscription_BodyEndPoint_WithoutSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -118,7 +119,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_BodyEndPoint_WithSubscriberId()
+        public async Task AddSubscription_BodyEndPoint_WithSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -140,7 +141,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_FoodEndPoint_WithoutSubscriberId()
+        public async Task AddSubscription_FoodEndPoint_WithoutSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -156,7 +157,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_FoodEndPoint_WithSubscriberId()
+        public async Task AddSubscription_FoodEndPoint_WithSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -178,7 +179,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_MealsEndPoint_WithoutSubscriberId()
+        public async Task AddSubscription_MealsEndPoint_WithoutSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -194,7 +195,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_MealsEndPoint_WithSubscriberId()
+        public async Task AddSubscription_MealsEndPoint_WithSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -216,7 +217,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_SleepEndPoint_WithoutSubscriberId()
+        public async Task AddSubscription_SleepEndPoint_WithoutSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -232,7 +233,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_SleepEndPoint_WithSubscriberId()
+        public async Task AddSubscription_SleepEndPoint_WithSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -254,7 +255,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_WeightEndPoint_WithoutSubscriberId()
+        public async Task AddSubscription_WeightEndPoint_WithoutSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {
@@ -270,7 +271,7 @@ namespace Fitbit.Portable.Tests
 
         [Category("PubSub")]
         [Test] [Category("Portable")]
-        public async void AddSubscription_WeightEndPoint_WithSubscriberId()
+        public async Task AddSubscription_WeightEndPoint_WithSubscriberId()
         {
             Action<HttpRequestMessage> additionalChecks = message =>
             {

--- a/Fitbit.Portable.Tests/BloodPressureTests.cs
+++ b/Fitbit.Portable.Tests/BloodPressureTests.cs
@@ -15,7 +15,7 @@ namespace Fitbit.Portable.Tests
     public class BloodPressureTests
     {       
         [Test] [Category("Portable")]
-        public async void GetBloodPressureAsync_Success()
+        public async Task GetBloodPressureAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetBloodPressure.json");
 

--- a/Fitbit.Portable.Tests/BodyMeasurementTests.cs
+++ b/Fitbit.Portable.Tests/BodyMeasurementTests.cs
@@ -14,7 +14,7 @@ namespace Fitbit.Portable.Tests
     public class BodyMeasurementTests
     {
         [Test] [Category("Portable")]
-        public async void GetBodyMeasurementsAsync_Success()
+        public async Task GetBodyMeasurementsAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetBodyMeasurements.json");
 

--- a/Fitbit.Portable.Tests/DayActivityTests.cs
+++ b/Fitbit.Portable.Tests/DayActivityTests.cs
@@ -15,7 +15,7 @@ namespace Fitbit.Portable.Tests
     public class DayActivityTests
     {
         [Test] [Category("Portable")]
-        public async void GetDayActivityAsync_Success()
+        public async Task GetDayActivityAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetActivities.json");
 
@@ -54,7 +54,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void GetDayActivitySummaryAsync_Success()
+        public async Task GetDayActivitySummaryAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetActivities.json");
 

--- a/Fitbit.Portable.Tests/DeviceTests.cs
+++ b/Fitbit.Portable.Tests/DeviceTests.cs
@@ -16,7 +16,7 @@ namespace Fitbit.Portable.Tests
     public class DeviceTests
     {
         [Test] [Category("Portable")]
-        public async void GetDevicesAsync_Success()
+        public async Task GetDevicesAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetDevices-Single.json");
 
@@ -41,7 +41,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void GetDevicesAsync_Success_Mulitiple()
+        public async Task GetDevicesAsync_Success_Mulitiple()
         {
             string content = SampleDataHelper.GetContent("GetDevices-Double.json");
 

--- a/Fitbit.Portable.Tests/FatTests.cs
+++ b/Fitbit.Portable.Tests/FatTests.cs
@@ -7,6 +7,7 @@ using Fitbit.Api.Portable;
 using Fitbit.Models;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using System.Threading.Tasks;
 
 namespace Fitbit.Portable.Tests
 {
@@ -21,143 +22,173 @@ namespace Fitbit.Portable.Tests
             fixture = new Fixture();
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentException))]
-        public async void GetFatAsync_DateRangePeriod_ThreeMonths()
+        [Test]
+        [Category("Portable")]
+        public void GetFatAsync_DateRangePeriod_ThreeMonths()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.GetFatAsync(DateTime.Now, DateRangePeriod.ThreeMonths);
+
+            Assert.That(new AsyncTestDelegate(async () => await client.GetFatAsync(DateTime.Now, DateRangePeriod.ThreeMonths)), Throws.ArgumentException);
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentException))]
-        public async void GetFatAsync_DateRangePeriod_SixMonths()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFatAsync_DateRangePeriod_SixMonths()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.GetFatAsync(DateTime.Now, DateRangePeriod.SixMonths);
+            Assert.That(
+                new AsyncTestDelegate(async () => await client.GetFatAsync(DateTime.Now, DateRangePeriod.SixMonths)),
+                Throws.ArgumentException
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentException))]
-        public async void GetFatAsync_DateRangePeriod_OneYear()
+        [Test]
+        [Category("Portable")]
+        public void GetFatAsync_DateRangePeriod_OneYear()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.GetFatAsync(DateTime.Now, DateRangePeriod.OneYear);
+            Assert.That(
+                new AsyncTestDelegate(async () => await client.GetFatAsync(DateTime.Now, DateRangePeriod.OneYear)),
+                Throws.ArgumentException
+                );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentException))]
-        public async void GetFatAsync_DateRangePeriod_Max()
+        [Test]
+        [Category("Portable")]
+        public void GetFatAsync_DateRangePeriod_Max()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.GetFatAsync(DateTime.Now, DateRangePeriod.Max);
+            Assert.That(new AsyncTestDelegate(async () => await client.GetFatAsync(DateTime.Now, DateRangePeriod.Max)),
+                Throws.ArgumentException
+                );
         }
 
-        [Test] [Category("Portable")]
-        public async void GetFatAsync_OneDay_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFatAsync_OneDay_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/fat/date/2012-03-05/1d.json");
 
             var response = await fitbitClient.GetFatAsync(new DateTime(2012, 3, 5), DateRangePeriod.OneDay);
-            
+
             ValidateFat(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetFatAsync_SevenDay_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFatAsync_SevenDay_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/fat/date/2012-03-05/7d.json");
 
             var response = await fitbitClient.GetFatAsync(new DateTime(2012, 3, 5), DateRangePeriod.SevenDays);
-            
+
             ValidateFat(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetFatAsync_OneWeek_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFatAsync_OneWeek_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/fat/date/2012-03-05/1w.json");
 
             var response = await fitbitClient.GetFatAsync(new DateTime(2012, 3, 5), DateRangePeriod.OneWeek);
-            
+
             ValidateFat(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetFatAsync_ThirtyDays_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFatAsync_ThirtyDays_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/fat/date/2012-03-05/30d.json");
 
             var response = await fitbitClient.GetFatAsync(new DateTime(2012, 3, 5), DateRangePeriod.ThirtyDays);
-            
+
             ValidateFat(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetFatAsync_OneMonth_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFatAsync_OneMonth_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/fat/date/2012-03-05/1m.json");
 
             var response = await fitbitClient.GetFatAsync(new DateTime(2012, 3, 5), DateRangePeriod.OneMonth);
-            
+
             ValidateFat(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetFatAsync_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFatAsync_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/fat/date/2012-03-05.json");
 
             var response = await fitbitClient.GetFatAsync(new DateTime(2012, 3, 5));
-            
+
             ValidateFat(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetFatAsync_TimeSpan_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFatAsync_TimeSpan_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/fat/date/2012-03-05/2012-03-06.json");
 
             var response = await fitbitClient.GetFatAsync(new DateTime(2012, 3, 5), new DateTime(2012, 3, 6));
-            
+
             ValidateFat(response);
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
-        public async void GetFatAsync_DateRange_Span_Too_Large()
+        [Test]
+        [Category("Portable")]
+        public void GetFatAsync_DateRange_Span_Too_Large()
         {
             var fitbitClient = Helper.CreateFitbitClient(() => new HttpResponseMessage(), (r, c) => { });
             var basedate = DateTime.Now;
-            
-            await fitbitClient.GetFatAsync(basedate.AddDays(-35), basedate);
+
+            Assert.That(
+                new AsyncTestDelegate(async () => await fitbitClient.GetFatAsync(basedate.AddDays(-35), basedate)),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+            );
+
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_Empty_String()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetFat(string.Empty);
+            Assert.That(
+                new TestDelegate(()=>deserializer.GetFat(string.Empty)),
+                Throws.ArgumentNullException)
+            ;
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_Null_String()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetFat(null);
+            Assert.That(
+                new TestDelegate(() => deserializer.GetFat(null)),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_WhiteSpace()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetFat("         ");
+            Assert.That(
+                new TestDelegate(() => deserializer.GetFat("         ")),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
+        [Test]
+        [Category("Portable")]
         public void Can_Deserialize_Fat()
         {
             string content = SampleDataHelper.GetContent("GetFat.json");
@@ -198,7 +229,7 @@ namespace Fitbit.Portable.Tests
             Assert.AreEqual(new DateTime(2012, 3, 5), log.Date);
             Assert.AreEqual(1330991999000, log.LogId);
             Assert.AreEqual(14, log.Fat);
-            Assert.AreEqual(new DateTime(2012, 3,5,23,59,59).TimeOfDay, log.Time.TimeOfDay);
+            Assert.AreEqual(new DateTime(2012, 3, 5, 23, 59, 59).TimeOfDay, log.Time.TimeOfDay);
 
             fat.FatLogs.Remove(log);
             log = fat.FatLogs.First();

--- a/Fitbit.Portable.Tests/FatTests.cs
+++ b/Fitbit.Portable.Tests/FatTests.cs
@@ -33,7 +33,7 @@ namespace Fitbit.Portable.Tests
 
         [Test]
         [Category("Portable")]
-        public async Task GetFatAsync_DateRangePeriod_SixMonths()
+        public void GetFatAsync_DateRangePeriod_SixMonths()
         {
             var client = fixture.Create<FitbitClient>();
             Assert.That(

--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -128,135 +128,185 @@
     <None Include="app.config" />
     <None Include="packages.config" />
     <Content Include="SampleData\ActivitiesStats.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\ActivityGoals.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\AddSubscriptionResponse.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\ApiError-Request-Forbidden.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\ApiError-Request-StaleToken.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\ApiError-Request-Unauthorized.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\ApiError-Request-BadRequest.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\ApiSubscriptionNotification.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetActivities.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetBloodPressure.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetBodyMeasurements.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetFriends-Single-2.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetHeartRate.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetWater-WaterData.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetWeight.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetFat.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetFoodLogs.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetFriends-Multiple.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetDevices-Double.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetDevices-Single.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="SampleData\AccessToken.json" />
-    <None Include="SampleData\ActivitiesStats.json" />
-    <None Include="SampleData\ActivityGoals.json" />
-    <None Include="SampleData\AddSubscriptionResponse.json" />
-    <None Include="SampleData\ApiError-Request-Forbidden.json" />
-    <None Include="SampleData\ApiError-Request-StaleToken.json" />
-    <None Include="SampleData\ApiError-Request-Unauthorized.json" />
-    <None Include="SampleData\ApiError-Request-BadRequest.json" />
-    <None Include="SampleData\ApiSubscriptionNotification.json" />
-    <None Include="SampleData\GetActivities.json" />
-    <None Include="SampleData\GetBloodPressure.json" />
-    <None Include="SampleData\GetBodyMeasurements.json" />
-    <None Include="SampleData\GetFriends-Single-2.json" />
-    <None Include="SampleData\GetHeartRate.json" />
-    <None Include="SampleData\GetSleepRange.json" />
-    <None Include="SampleData\GetSleep.json" />
-    <None Include="SampleData\GetWater-WaterData.json" />
-    <None Include="SampleData\GetWeight.json" />
-    <None Include="SampleData\GetFat.json" />
-    <None Include="SampleData\GetFoodLogs.json" />
-    <None Include="SampleData\GetFriends-Multiple.json" />
-    <None Include="SampleData\GetDevices-Double.json" />
-    <None Include="SampleData\GetDevices-Single.json" />
+    <None Include="SampleData\AccessToken.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\ActivitiesStats.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\ActivityGoals.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\AddSubscriptionResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\ApiError-Request-Forbidden.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\ApiError-Request-StaleToken.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\ApiError-Request-Unauthorized.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\ApiError-Request-BadRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\ApiSubscriptionNotification.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetActivities.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetBloodPressure.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetBodyMeasurements.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetFriends-Single-2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetHeartRate.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetSleepRange.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetSleep.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetWater-WaterData.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetWeight.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetFat.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetFoodLogs.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetFriends-Multiple.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetDevices-Double.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SampleData\GetDevices-Single.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Content Include="SampleData\IntradayActivitiesSteps.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\IntradayActivitiesCaloriesMissingDateTime.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="SampleData\ApiError.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetFriends-None.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetFriends-Single.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\GetSleepOld.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\IntradayActivitiesCalories.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\ListApiSubscriptions.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\ListApiSubscriptionsResponseMultiple.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\LogWater-WaterLog.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="SampleData\MultipleSingleSubscriptionNotification.xml" />
-    <Content Include="SampleData\SingleSubscriptionNotification.xml" />
+    <Content Include="SampleData\MultipleSingleSubscriptionNotification.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SampleData\SingleSubscriptionNotification.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleData\TimeSeries-ActivitiesSteps.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\TimeSeries-ActivitiesDistance.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleData\UserProfile.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="SampleData\ListApiSubscriptionsResponseSingle.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Fitbit\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\Fitbit\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,6 +18,8 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\Fitbit\</SolutionDir>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,65 +39,39 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Fitbit\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Fitbit\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
-      <HintPath>..\Fitbit\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Moq, Version=4.7.99.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Moq.4.7.99\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\Fitbit\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.40.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\Fitbit\packages\AutoFixture.3.40.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\AutoFixture.3.50.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+sl5+win8+wp8+wpa81\System.Threading.Tasks.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Xml" />
@@ -308,6 +285,12 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\Fitbit\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\Fitbit\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Fitbit.Portable.Tests/FitbitHttpMessageHandlerTests.cs
+++ b/Fitbit.Portable.Tests/FitbitHttpMessageHandlerTests.cs
@@ -92,7 +92,6 @@
         [Category("OAuth2")]
         public void Can_Handle_Failed_Refresh_Operation()
         {
-            const int EXPECT_TWO_COUNT_STALE_AND_RETRY = 2;
             var originalToken = new OAuth2AccessToken() { Token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0MzAzNDM3MzUsInNjb3BlcyI6Indwcm8gd2xvYyB3bnV0IHdzbGUgd3NldCB3aHIgd3dlaSB3YWN0IHdzb2MiLCJzdWIiOiJBQkNERUYiLCJhdWQiOiJJSktMTU4iLCJpc3MiOiJGaXRiaXQiLCJ0eXAiOiJhY2Nlc3NfdG9rZW4iLCJpYXQiOjE0MzAzNDAxMzV9.z0VHrIEzjsBnjiNMBey6wtu26yHTnSWz_qlqoEpUlpc" };
             var refreshedToken = new OAuth2AccessToken() { Token = "Refreshed" };
 
@@ -163,10 +162,10 @@
                     return null;
             }
 
-            public async Task<HttpResponseMessage> InterceptResponse(Task<HttpResponseMessage> response, CancellationToken cancellationToken, FitbitClient client)
+            public Task<HttpResponseMessage> InterceptResponse(Task<HttpResponseMessage> response, CancellationToken cancellationToken, FitbitClient client)
             {
                 //let the pipeline continue
-                return null;
+                return Task.FromResult<HttpResponseMessage>(null);
             }
         }
     }

--- a/Fitbit.Portable.Tests/FoodTests.cs
+++ b/Fitbit.Portable.Tests/FoodTests.cs
@@ -15,7 +15,7 @@ namespace Fitbit.Portable.Tests
     public class FoodTests
     {
         [Test] [Category("Portable")]
-        public async void GetFoodAsync_Success()
+        public async Task GetFoodAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetFoodLogs.json");
 

--- a/Fitbit.Portable.Tests/FriendsTests.cs
+++ b/Fitbit.Portable.Tests/FriendsTests.cs
@@ -15,8 +15,9 @@ namespace Fitbit.Portable.Tests
     [TestFixture]
     public class FriendsTests
     {
-        [Test] [Category("Portable")]
-        public async void GetFriendsMultipleAsync_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFriendsMultipleAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetFriends-Multiple.json");
 
@@ -32,15 +33,16 @@ namespace Fitbit.Portable.Tests
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
-            
+
             var response = await fitbitClient.GetFriendsAsync();
-            
+
             Assert.AreEqual(3, response.Count);
             ValidateMultipleFriends(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetFriendsSingleAsync_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetFriendsSingleAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetFriends-Single.json");
 
@@ -56,13 +58,14 @@ namespace Fitbit.Portable.Tests
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
-            
+
             var response = await fitbitClient.GetFriendsAsync();
-            
+
             ValidateSingleFriend(response);
         }
 
-        [Test] [Category("Portable")]
+        [Test]
+        [Category("Portable")]
         public void GetFriendsAsync_Failure_Errors()
         {
             var responseMessage = Helper.CreateErrorResponse();
@@ -72,42 +75,53 @@ namespace Fitbit.Portable.Tests
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
-            
+
             Func<Task<List<UserProfile>>> result = () => fitbitClient.GetFriendsAsync();
 
             result.ShouldThrow<FitbitException>();
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_Empty_String()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetFriends(string.Empty);
+            Assert.That(
+                new TestDelegate(() => deserializer.GetFriends(string.Empty)),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_Null_String()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetFriends(null);
+            
+            Assert.That(
+                new TestDelegate(() => deserializer.GetFriends(null)),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_WhiteSpace()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetFriends("         ");
+            Assert.That(
+                new TestDelegate(() => deserializer.GetFriends("         ")),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
+        [Test]
+        [Category("Portable")]
         public void Can_Deserialize_Friends_Multiple()
         {
             string content = SampleDataHelper.GetContent("GetFriends-Multiple.json");
             var deserializer = new JsonDotNetSerializer();
-            
+
             List<UserProfile> friends = deserializer.GetFriends(content);
 
             Assert.IsNotNull(friends);
@@ -116,7 +130,8 @@ namespace Fitbit.Portable.Tests
             ValidateMultipleFriends(friends);
         }
 
-        [Test] [Category("Portable")]
+        [Test]
+        [Category("Portable")]
         public void Can_Deserialize_Friends_Single()
         {
             string content = SampleDataHelper.GetContent("GetFriends-Single.json");
@@ -128,7 +143,8 @@ namespace Fitbit.Portable.Tests
             ValidateSingleFriend(friends);
         }
 
-        [Test] [Category("Portable")]
+        [Test]
+        [Category("Portable")]
         public void Can_Deserialize_Friends_Single_NullDateOfBirth()
         {
             string content = SampleDataHelper.GetContent("GetFriends-Single-2.json");
@@ -140,7 +156,8 @@ namespace Fitbit.Portable.Tests
             ValidateSingleFriendNullDateOfBirth(friends);
         }
 
-        [Test] [Category("Portable")]
+        [Test]
+        [Category("Portable")]
         public void Can_Deserialize_Friends_None()
         {
             string content = SampleDataHelper.GetContent("GetFriends-None.json");
@@ -244,28 +261,28 @@ namespace Fitbit.Portable.Tests
         }
 
         private void ValidateSingleFriendNullDateOfBirth(List<UserProfile> friends)
-        {  
-            Assert.IsTrue(friends.Count == 1);  
-        
-            var friend = friends.First();  
-            Assert.AreEqual("http://www.fitbit.com/images/profile/defaultProfile_100_female.gif", friend.Avatar);  
-            Assert.AreEqual("http://www.fitbit.com/images/profile/defaultProfile_150_female.gif", friend.Avatar150);  
-            Assert.AreEqual("GB", friend.Country);  
-            Assert.AreEqual(DateTime.MinValue, friend.DateOfBirth);  
-            Assert.AreEqual("Laura", friend.DisplayName);  
-            Assert.AreEqual("24WXXX", friend.EncodedId);  
-            Assert.AreEqual("", friend.FullName);  
-            Assert.AreEqual(Gender.FEMALE, friend.Gender);  
-            Assert.AreEqual(165, friend.Height);  
-            Assert.AreEqual("en_GB", friend.Locale);  
-            Assert.AreEqual(DateTime.Parse("2013-02-01"), friend.MemberSince);  
-            Assert.AreEqual("", friend.Nickname);  
-            Assert.AreEqual(3600000, friend.OffsetFromUTCMillis);  
-            Assert.AreEqual("SUNDAY", friend.StartDayOfWeek);  
-            Assert.AreEqual(0, friend.StrideLengthRunning);  
-            Assert.AreEqual(0, friend.StrideLengthWalking);  
-            Assert.AreEqual("Europe/London", friend.Timezone);  
-            Assert.AreEqual(0, friend.Weight);  
+        {
+            Assert.IsTrue(friends.Count == 1);
+
+            var friend = friends.First();
+            Assert.AreEqual("http://www.fitbit.com/images/profile/defaultProfile_100_female.gif", friend.Avatar);
+            Assert.AreEqual("http://www.fitbit.com/images/profile/defaultProfile_150_female.gif", friend.Avatar150);
+            Assert.AreEqual("GB", friend.Country);
+            Assert.AreEqual(DateTime.MinValue, friend.DateOfBirth);
+            Assert.AreEqual("Laura", friend.DisplayName);
+            Assert.AreEqual("24WXXX", friend.EncodedId);
+            Assert.AreEqual("", friend.FullName);
+            Assert.AreEqual(Gender.FEMALE, friend.Gender);
+            Assert.AreEqual(165, friend.Height);
+            Assert.AreEqual("en_GB", friend.Locale);
+            Assert.AreEqual(DateTime.Parse("2013-02-01"), friend.MemberSince);
+            Assert.AreEqual("", friend.Nickname);
+            Assert.AreEqual(3600000, friend.OffsetFromUTCMillis);
+            Assert.AreEqual("SUNDAY", friend.StartDayOfWeek);
+            Assert.AreEqual(0, friend.StrideLengthRunning);
+            Assert.AreEqual(0, friend.StrideLengthWalking);
+            Assert.AreEqual("Europe/London", friend.Timezone);
+            Assert.AreEqual(0, friend.Weight);
         }
     }
 }

--- a/Fitbit.Portable.Tests/GoalsTests.cs
+++ b/Fitbit.Portable.Tests/GoalsTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Fitbit.Api.Portable;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using System.Threading.Tasks;
 
 namespace Fitbit.Portable.Tests
 {
@@ -13,22 +14,22 @@ namespace Fitbit.Portable.Tests
     {
         public Fixture fixture { get; set; }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Init()
         {
             fixture = new Fixture();
         }
 
         [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentException))]
-        public async void SetGoalsAsync_NoGoalsSet()
+        public void SetGoalsAsync_NoGoalsSet()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.SetGoalsAsync();
+            Assert.That(new AsyncTestDelegate(async () => await client.SetGoalsAsync()), Throws.ArgumentException);
+            
         }
 
         [Test] [Category("Portable")]
-        public async void SetGoalsAsync_CaloriesOutSet()
+        public async Task SetGoalsAsync_CaloriesOutSet()
         {
             var fitbitClient = SetupFitbitClient("caloriesOut=2000");
 
@@ -38,7 +39,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void SetGoalsAsync_DistanceSet()
+        public async Task SetGoalsAsync_DistanceSet()
         {
             var fitbitClient = SetupFitbitClient("distance=8.5");
 
@@ -48,7 +49,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void SetGoalsAsync_FloorsSet()
+        public async Task SetGoalsAsync_FloorsSet()
         {
             var fitbitClient = SetupFitbitClient("floors=20");
 
@@ -58,7 +59,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void SetGoalsAsync_StepsSet()
+        public async Task SetGoalsAsync_StepsSet()
         {
             var fitbitClient = SetupFitbitClient("steps=10000");
 
@@ -68,7 +69,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void SetGoalsAsync_ActiveMinuitesSet()
+        public async Task SetGoalsAsync_ActiveMinuitesSet()
         {
             var fitbitClient = SetupFitbitClient("activeMinutes=50");
 
@@ -78,7 +79,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void SetGoalsAsync_AllSet()
+        public async Task SetGoalsAsync_AllSet()
         {
             var fitbitClient = SetupFitbitClient("caloriesOut=2000&distance=8.5&floors=20&steps=10000&activeMinutes=50");
 

--- a/Fitbit.Portable.Tests/Helpers/ResponseFaker.cs
+++ b/Fitbit.Portable.Tests/Helpers/ResponseFaker.cs
@@ -39,10 +39,10 @@ namespace Fitbit.Portable.Tests.Helpers
                 return null;
         }
 
-        public async Task<HttpResponseMessage> InterceptResponse(Task<HttpResponseMessage> response, CancellationToken cancellationToken, FitbitClient client)
+        public Task<HttpResponseMessage> InterceptResponse(Task<HttpResponseMessage> response, CancellationToken cancellationToken, FitbitClient client)
         {
             ResponseCount++;
-            return null;
+            return Task.FromResult<HttpResponseMessage>(null);
         }
 
     }

--- a/Fitbit.Portable.Tests/Interceptors/FitbitHttpErrorHandlerTests.cs
+++ b/Fitbit.Portable.Tests/Interceptors/FitbitHttpErrorHandlerTests.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Fitbit.Api.Portable;
 using Fitbit.Api.Portable.Interceptors;
-using NUnit.Core;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.Kernel;
@@ -28,22 +27,23 @@ namespace Fitbit.Portable.Tests.Interceptors
             fixture.Customizations.Add(new TypeRelay(typeof(HttpContent), typeof(ByteArrayContent)));
         }
 
-        //TO DO: Migrate to newer framework to move away from atribute base exception checking
         [Test]
-        [ExpectedException(typeof(FitbitRequestException))]
-        public async void Throws_On_500()
+        public void Throws_On_500()
         {
             var cancellationToken = new CancellationToken();
             var unsuccesfulResponse =
                 fixture.Build<HttpResponseMessage>().With(r => r.StatusCode, HttpStatusCode.InternalServerError).Create();
             var sut = fixture.Create<FitbitHttpErrorHandler>();
 
-            await sut.InterceptResponse(Task.FromResult(unsuccesfulResponse), cancellationToken, null);
+            Assert.That(
+                new AsyncTestDelegate(async () => await sut.InterceptResponse(Task.FromResult(unsuccesfulResponse), cancellationToken, null)),
+                Throws.InstanceOf<FitbitRequestException>()
+            );
         }
 
         //TO DO: Migrate to newer framework to move away from atribute base exception checking
         [Test]
-        public async void Proceeds_On_200()
+        public async Task Proceeds_On_200()
         {
             var cancellationToken = new CancellationToken();
             var unsuccesfulResponse =

--- a/Fitbit.Portable.Tests/IntradayTimeSeriesTests.cs
+++ b/Fitbit.Portable.Tests/IntradayTimeSeriesTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Fitbit.Models;
 using FluentAssertions;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace Fitbit.Portable.Tests
 {
@@ -13,7 +14,7 @@ namespace Fitbit.Portable.Tests
     {
         [Test]
         [Category("Portable")]
-        public async void GetIntraDayTimeSeriesCaloriesIntensityMetsAsync_Success()
+        public async Task GetIntraDayTimeSeriesCaloriesIntensityMetsAsync_Success()
         {
             DateTime expectedResult = new DateTime(2015, 3, 20, 0, 1, 0);
 
@@ -40,7 +41,7 @@ namespace Fitbit.Portable.Tests
 
         [Test]
         [Category("Portable")]
-        public async void GetIntraDayTimeSeriesCaloriesIntensityMetsAsync_ReturnsNullIfMissingDateTime()
+        public async Task GetIntraDayTimeSeriesCaloriesIntensityMetsAsync_ReturnsNullIfMissingDateTime()
         {
             string content = SampleDataHelper.GetContent("IntradayActivitiesCaloriesMissingDateTime.json");
             var responseMessage = new Func<HttpResponseMessage>(() =>
@@ -62,7 +63,7 @@ namespace Fitbit.Portable.Tests
 
         [Test]
         [Category("Portable")]
-        public async void GetIntraDayTimeSeriesStepsAsync_Success()
+        public async Task GetIntraDayTimeSeriesStepsAsync_Success()
         {
             DateTime expectedResult = new DateTime(2016, 3, 8, 0, 1, 0);
 

--- a/Fitbit.Portable.Tests/SampleDataHelper.cs
+++ b/Fitbit.Portable.Tests/SampleDataHelper.cs
@@ -4,7 +4,7 @@ namespace Fitbit.Portable.Tests
 {
     public static class SampleDataHelper
     {
-        private static readonly string SampleDataPath = Path.Combine(Path.GetFullPath(@"..\..\"), "SampleData");
+        private static readonly string SampleDataPath = Path.Combine(Path.GetDirectoryName(typeof(SampleDataHelper).Assembly.Location), "SampleData");
 
         private static string PathFor(string sampleFile)
         {

--- a/Fitbit.Portable.Tests/SleepTests.cs
+++ b/Fitbit.Portable.Tests/SleepTests.cs
@@ -16,7 +16,7 @@ namespace Fitbit.Portable.Tests
     {
         [Test]
         [Category("Portable")]
-        public async void GetSleepAsyncOld_Success()
+        public async Task GetSleepAsyncOld_Success()
         {
             string content = SampleDataHelper.GetContent("GetSleepOld.json");
 
@@ -41,7 +41,7 @@ namespace Fitbit.Portable.Tests
 
         [Test]
         [Category("Portable")]
-        public async void GetSleepAsync_Success()
+        public async Task GetSleepAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetSleep.json");
 

--- a/Fitbit.Portable.Tests/TimeSeriesDataListIntTests.cs
+++ b/Fitbit.Portable.Tests/TimeSeriesDataListIntTests.cs
@@ -6,14 +6,16 @@ using System.Threading;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace Fitbit.Portable.Tests
 {
     [TestFixture]
     public class TimeSeriesDataListIntTests
     {
-        [Test] [Category("Portable")]
-        public async void GetTimeSeriesDataListIntAsync_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetTimeSeriesDataListIntAsync_Success()
         {
             string content = SampleDataHelper.GetContent("TimeSeries-ActivitiesSteps.json");
 
@@ -29,14 +31,15 @@ namespace Fitbit.Portable.Tests
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
-            
+
             var response = await fitbitClient.GetTimeSeriesIntAsync(TimeSeriesResourceType.Steps, new DateTime(2014, 9, 4), DateRangePeriod.SevenDays);
 
             ValidateDataList(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetTimeSeriesDataListIntAsync_DoubleDate_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetTimeSeriesDataListIntAsync_DoubleDate_Success()
         {
             string content = SampleDataHelper.GetContent("TimeSeries-ActivitiesSteps.json");
 
@@ -52,21 +55,25 @@ namespace Fitbit.Portable.Tests
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
-            
+
             var response = await fitbitClient.GetTimeSeriesIntAsync(TimeSeriesResourceType.Steps, new DateTime(2014, 9, 4), new DateTime(2014, 9, 7));
 
             ValidateDataList(response);
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Serializer_Passed_Invalid_Data_To_Serialize()
         {
             var serialiser = new JsonDotNetSerializer();
-            serialiser.GetTimeSeriesDataListInt(string.Empty);
+            Assert.That(
+                new TestDelegate(() => serialiser.GetTimeSeriesDataListInt(string.Empty)),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
+        [Test]
+        [Category("Portable")]
         public void Can_Deserialize_Activities_Distance()
         {
             string content = SampleDataHelper.GetContent("TimeSeries-ActivitiesSteps.json");

--- a/Fitbit.Portable.Tests/TimeSeriesDataListTests.cs
+++ b/Fitbit.Portable.Tests/TimeSeriesDataListTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace Fitbit.Portable.Tests
 {
@@ -13,7 +14,7 @@ namespace Fitbit.Portable.Tests
     public class TimeSeriesDataListTests
     {
         [Test] [Category("Portable")]
-        public async void GetTimeSeriesDataListAsync_Success()
+        public async Task GetTimeSeriesDataListAsync_Success()
         {
             string content = SampleDataHelper.GetContent("TimeSeries-ActivitiesDistance.json");
 
@@ -36,7 +37,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void GetTimeSeriesDataListAsync_DoubleDate_Success()
+        public async Task GetTimeSeriesDataListAsync_DoubleDate_Success()
         {
             string content = SampleDataHelper.GetContent("TimeSeries-ActivitiesDistance.json");
 
@@ -59,11 +60,14 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        [ExpectedException(typeof(ArgumentNullException))]
+        //TODO: fix [ExpectedException(typeof(ArgumentNullException))]
         public void Serializer_Passed_Invalid_Data_To_Serialize()
         {
             var serialiser = new JsonDotNetSerializer();
-            serialiser.GetTimeSeriesDataList(string.Empty);
+            Assert.That(
+                new TestDelegate(()=> serialiser.GetTimeSeriesDataList(string.Empty)),
+                Throws.ArgumentNullException
+                );
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/UserProfileTests.cs
+++ b/Fitbit.Portable.Tests/UserProfileTests.cs
@@ -15,7 +15,7 @@ namespace Fitbit.Portable.Tests
     public class UserProfileTests
     {
         [Test] [Category("Portable")]
-        public async void GetUserProfileAsync_Success()
+        public async Task GetUserProfileAsync_Success()
         {
             string content = SampleDataHelper.GetContent("UserProfile.json");
 

--- a/Fitbit.Portable.Tests/WaterTests.cs
+++ b/Fitbit.Portable.Tests/WaterTests.cs
@@ -15,7 +15,7 @@ namespace Fitbit.Portable.Tests
     public class WaterTests
     {
         [Test] [Category("Portable")]
-        public async void GetWaterAsync_Success()
+        public async Task GetWaterAsync_Success()
         {
             string content = SampleDataHelper.GetContent("GetWater-WaterData.json");
 
@@ -54,7 +54,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void PostWaterLogAsync_Success()
+        public async Task PostWaterLogAsync_Success()
         {
             string content = SampleDataHelper.GetContent("LogWater-WaterLog.json");
 
@@ -77,7 +77,7 @@ namespace Fitbit.Portable.Tests
         }
 
         [Test] [Category("Portable")]
-        public async void DeleteWaterLogAsync_Success()
+        public async Task DeleteWaterLogAsync_Success()
         {
             var responseMessage = new Func<HttpResponseMessage>(() =>
             {

--- a/Fitbit.Portable.Tests/WeightTests.cs
+++ b/Fitbit.Portable.Tests/WeightTests.cs
@@ -7,6 +7,7 @@ using Fitbit.Api.Portable;
 using Fitbit.Models;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using System.Threading.Tasks;
 
 namespace Fitbit.Portable.Tests
 {
@@ -21,40 +22,55 @@ namespace Fitbit.Portable.Tests
             fixture = new Fixture();
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof (ArgumentOutOfRangeException))]
-        public async void GetWeightAsync_DateRangePeriod_ThreeMonths()
+        [Test]
+        [Category("Portable")]
+        public void GetWeightAsync_DateRangePeriod_ThreeMonths()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.GetWeightAsync(DateTime.Now, DateRangePeriod.ThreeMonths);
+            Assert.That(
+                new AsyncTestDelegate(async () => await client.GetWeightAsync(DateTime.Now, DateRangePeriod.ThreeMonths)),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof (ArgumentOutOfRangeException))]
-        public async void GetWeightAsync_DateRangePeriod_SixMonths()
+        [Test]
+        [Category("Portable")]
+        public void GetWeightAsync_DateRangePeriod_SixMonths()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.GetWeightAsync(DateTime.Now, DateRangePeriod.SixMonths);
+            Assert.That(
+                new AsyncTestDelegate(async () => await client.GetWeightAsync(DateTime.Now, DateRangePeriod.SixMonths)),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof (ArgumentOutOfRangeException))]
-        public async void GetWeightAsync_DateRangePeriod_OneYear()
+        [Test]
+        [Category("Portable")]
+        public void GetWeightAsync_DateRangePeriod_OneYear()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.GetWeightAsync(DateTime.Now, DateRangePeriod.OneYear);
+            ;
+            Assert.That(
+                new AsyncTestDelegate(async () => await client.GetWeightAsync(DateTime.Now, DateRangePeriod.OneYear)),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof (ArgumentOutOfRangeException))]
-        public async void GetWeightAsync_DateRangePeriod_Max()
+        [Test]
+        [Category("Portable")]
+        public void GetWeightAsync_DateRangePeriod_Max()
         {
             var client = fixture.Create<FitbitClient>();
-            await client.GetWeightAsync(DateTime.Now, DateRangePeriod.Max);
+
+            Assert.That(
+                    new AsyncTestDelegate(async () => await client.GetWeightAsync(DateTime.Now, DateRangePeriod.Max)),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                );
         }
 
-        [Test] [Category("Portable")]
-        public async void GetWeightAsync_OneDay_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetWeightAsync_OneDay_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/weight/date/2012-03-05/1d.json");
 
@@ -63,8 +79,9 @@ namespace Fitbit.Portable.Tests
             ValidateWeight(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetWeightAsync_SevenDay_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetWeightAsync_SevenDay_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/weight/date/2012-03-05/7d.json");
 
@@ -73,48 +90,53 @@ namespace Fitbit.Portable.Tests
             ValidateWeight(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetWeightAsync_OneWeek_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetWeightAsync_OneWeek_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/weight/date/2012-03-05/1w.json");
 
             var response = await fitbitClient.GetWeightAsync(new DateTime(2012, 3, 5), DateRangePeriod.OneWeek);
-            
+
             ValidateWeight(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetWeightAsync_ThirtyDays_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetWeightAsync_ThirtyDays_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/weight/date/2012-03-05/30d.json");
 
             var response = await fitbitClient.GetWeightAsync(new DateTime(2012, 3, 5), DateRangePeriod.ThirtyDays);
-            
+
             ValidateWeight(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetWeightAsync_OneMonth_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetWeightAsync_OneMonth_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/weight/date/2012-03-05/1m.json");
 
             var response = await fitbitClient.GetWeightAsync(new DateTime(2012, 3, 5), DateRangePeriod.OneMonth);
-            
+
             ValidateWeight(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetWeightAsync_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetWeightAsync_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/weight/date/2012-03-05.json");
 
             var response = await fitbitClient.GetWeightAsync(new DateTime(2012, 3, 5));
-            
+
             ValidateWeight(response);
         }
 
-        [Test] [Category("Portable")]
-        public async void GetWeightAsync_TimeSpan_Success()
+        [Test]
+        [Category("Portable")]
+        public async Task GetWeightAsync_TimeSpan_Success()
         {
             var fitbitClient = SetupFitbitClient("https://api.fitbit.com/1/user/-/body/log/weight/date/2012-03-05/2012-03-06.json");
 
@@ -123,41 +145,57 @@ namespace Fitbit.Portable.Tests
             ValidateWeight(response);
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof (ArgumentOutOfRangeException))]
-        public async void GetWeightAsync_DateRange_Span_Too_Large()
+        [Test]
+        [Category("Portable")]
+        public void GetWeightAsync_DateRange_Span_Too_Large()
         {
             var fitbitClient = Helper.CreateFitbitClient(() => new HttpResponseMessage(), (r, c) => { });
             var basedate = DateTime.Now;
 
-            await fitbitClient.GetWeightAsync(basedate.AddDays(-35), basedate);
+            Assert.That(
+                    new AsyncTestDelegate(async () => await fitbitClient.GetWeightAsync(basedate.AddDays(-35), basedate)),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof (ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_Empty_String()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetWeight(string.Empty);
+
+            Assert.That(
+                new TestDelegate(() => deserializer.GetWeight(string.Empty)),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof (ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_Null_String()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetWeight(null);
+
+            Assert.That(
+                new TestDelegate(() => deserializer.GetWeight(null)),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
-        [ExpectedException(typeof (ArgumentNullException))]
+        [Test]
+        [Category("Portable")]
         public void Throws_Exception_With_WhiteSpace()
         {
             var deserializer = new JsonDotNetSerializer();
-            deserializer.GetWeight("         ");
+            
+            Assert.That(
+                new TestDelegate(() => deserializer.GetWeight("         ")),
+                Throws.ArgumentNullException
+            );
         }
 
-        [Test] [Category("Portable")]
+        [Test]
+        [Category("Portable")]
         public void Can_Deserialize_Weight()
         {
             string content = SampleDataHelper.GetContent("GetWeight.json");

--- a/Fitbit.Portable.Tests/app.config
+++ b/Fitbit.Portable.Tests/app.config
@@ -4,7 +4,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.22.0" newVersion="4.2.22.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Fitbit.Portable.Tests/packages.config
+++ b/Fitbit.Portable.Tests/packages.config
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.40.0" targetFramework="net45" />
-  <package id="FluentAssertions" version="4.2.1" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="AutoFixture" version="3.50.3" targetFramework="net45" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.19.3" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net45" />
-  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
+  <package id="Moq" version="4.7.99" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
+  <package id="NUnit" version="3.7.1" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net45" />
 </packages>

--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -16,6 +16,8 @@
     <TargetFrameworkProfile>Profile344</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\Fitbit\</SolutionDir>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -159,23 +161,23 @@
       <HintPath>..\Fitbit\packages\Newtonsoft.Json.8.0.2\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO">
-      <HintPath>..\Fitbit\packages\Microsoft.Bcl.1.1.9\lib\portable-net40+sl5+win8+wp8+wpa81\System.IO.dll</HintPath>
+    <Reference Include="System.IO, Version=1.5.11.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+sl5+win8+wp8+wpa81\System.IO.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http.Extensions, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime">
-      <HintPath>..\Fitbit\packages\Microsoft.Bcl.1.1.9\lib\portable-net40+sl5+win8+wp8+wpa81\System.Runtime.dll</HintPath>
+    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+sl5+win8+wp8+wpa81\System.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\Fitbit\packages\Microsoft.Bcl.1.1.9\lib\portable-net40+sl5+win8+wp8+wpa81\System.Threading.Tasks.dll</HintPath>
+    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\Fitbit\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+sl5+win8+wp8+wpa81\System.Threading.Tasks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -183,6 +185,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="..\Fitbit\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\Fitbit\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\Fitbit\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\Fitbit\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -137,7 +137,7 @@ namespace Fitbit.Api.Portable
         private void ConfigureTokenManager(ITokenManager tokenManager)
         {
             TokenManager = tokenManager ?? new DefaultTokenManager();
-            }
+        }
 
         private void CreateHttpClientForOAuth2()
         {
@@ -386,8 +386,6 @@ namespace Fitbit.Api.Portable
             return serializer.GetFriends(responseBody);
         }
 
-
-
         /// <summary>
         /// Request to get heart rate in specific in a range time
         /// </summary>
@@ -414,7 +412,6 @@ namespace Fitbit.Api.Portable
 
             return fitbitResponse;
         }
-
 
         /// <summary>
         /// Request to get heart rate in a day
@@ -444,11 +441,6 @@ namespace Fitbit.Api.Portable
 
             return seralizer.GetHeartRateIntraday(date, responseBody);
         }
-
-
-
-
-
 
         /// <summary>
         /// Requests the user profile of the encoded user id or if none specified the current logged in user

--- a/Fitbit.Portable/IFitbitClient.cs
+++ b/Fitbit.Portable/IFitbitClient.cs
@@ -18,6 +18,8 @@ namespace Fitbit.Api.Portable
         Task<SleepLogDateRange> PostLogSleepAsync(string startTime, int duration, DateTime date, string encodedUserId = default(string));
         Task<List<Device>> GetDevicesAsync();
         Task<List<UserProfile>> GetFriendsAsync(string encodedUserId = default(string));
+        Task<HeartActivitiesTimeSeries> GetHeartRateTimeSeries(DateTime date, DateRangePeriod dateRangePeriod, string userId = null);
+        Task<HeartActivitiesIntraday> GetHeartRateIntraday(DateTime date, HeartRateResolution resolution);
         Task<UserProfile> GetUserProfileAsync(string encodedUserId = default(string));
         Task<TimeSeriesDataList> GetTimeSeriesAsync(TimeSeriesResourceType timeSeriesResourceType, DateTime startDate, DateTime endDate, string encodedUserId = default(string));
         Task<TimeSeriesDataList> GetTimeSeriesAsync(TimeSeriesResourceType timeSeriesResourceType, DateTime endDate, DateRangePeriod period, string encodedUserId = default(string));

--- a/Fitbit.Portable/Models/HeartActivitiesIntraday.cs
+++ b/Fitbit.Portable/Models/HeartActivitiesIntraday.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-#if NETSTANDARD_13
+#if NETSTANDARD1_3
 using System.Reflection;
 #endif
 
@@ -86,7 +86,7 @@ namespace Fitbit.Models
 
         public override bool CanConvert(Type objectType)
         {
-#if NETSTANDARD_13
+#if NETSTANDARD1_3
             return typeof(HeartActivitiesIntraday).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
 #else
             return typeof(HeartActivitiesIntraday).IsAssignableFrom(objectType);

--- a/Fitbit.Portable/Models/HeartActivitiesIntraday.cs
+++ b/Fitbit.Portable/Models/HeartActivitiesIntraday.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+#if NETSTANDARD_13
+using System.Reflection;
+#endif
 
 namespace Fitbit.Models
 {
@@ -83,7 +86,11 @@ namespace Fitbit.Models
 
         public override bool CanConvert(Type objectType)
         {
+#if NETSTANDARD_13
+            return typeof(HeartActivitiesIntraday).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+#else
             return typeof(HeartActivitiesIntraday).IsAssignableFrom(objectType);
+#endif
         }
     }
 

--- a/Fitbit.Portable/StringAttributeExtensions.cs
+++ b/Fitbit.Portable/StringAttributeExtensions.cs
@@ -16,7 +16,11 @@ namespace Fitbit.Api.Portable
 
             //in the field's custom attributes
 
+#if NETSTANDARD_13
+            FieldInfo fi = type.GetTypeInfo().GetDeclaredField(value.ToString());
+#else
             FieldInfo fi = type.GetField(value.ToString());
+#endif
             StringValueAttribute[] attrs = fi.GetCustomAttributes(typeof(StringValueAttribute), false) as StringValueAttribute[];
             if (attrs.Length > 0)
             {

--- a/Fitbit.Portable/StringAttributeExtensions.cs
+++ b/Fitbit.Portable/StringAttributeExtensions.cs
@@ -16,7 +16,7 @@ namespace Fitbit.Api.Portable
 
             //in the field's custom attributes
 
-#if NETSTANDARD_13
+#if NETSTANDARD1_3
             FieldInfo fi = type.GetTypeInfo().GetDeclaredField(value.ToString());
 #else
             FieldInfo fi = type.GetField(value.ToString());

--- a/Fitbit.Portable/app.config
+++ b/Fitbit.Portable/app.config
@@ -4,11 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Fitbit.Portable/packages.config
+++ b/Fitbit.Portable/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable-net45+sl50+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable-net45+sl50+win+wp80+MonoAndroid10+MonoTouch10" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+sl50+win+wp80+MonoAndroid10+MonoTouch10" />
-  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net45+sl50+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="portable40-net45+sl5+win8+wp8" />
 </packages>

--- a/Fitbit/Fitbit.NetCore.sln
+++ b/Fitbit/Fitbit.NetCore.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26725.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fitbit.NetCore", "..\Fitbit.NetCore\Fitbit.NetCore.csproj", "{81F4F528-0E81-49E0-A2B2-ED77495A9C15}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitbit.NetCore.Tests", "..\Fitbit.NetCore.Tests\Fitbit.NetCore.Tests.csproj", "{DE9D7F3C-6F6C-43E2-AEE6-32E7DF894F3E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{81F4F528-0E81-49E0-A2B2-ED77495A9C15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81F4F528-0E81-49E0-A2B2-ED77495A9C15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81F4F528-0E81-49E0-A2B2-ED77495A9C15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81F4F528-0E81-49E0-A2B2-ED77495A9C15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE9D7F3C-6F6C-43E2-AEE6-32E7DF894F3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE9D7F3C-6F6C-43E2-AEE6-32E7DF894F3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE9D7F3C-6F6C-43E2-AEE6-32E7DF894F3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE9D7F3C-6F6C-43E2-AEE6-32E7DF894F3E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9DC6189B-479C-49B5-85B9-BD23083BC667}
+	EndGlobalSection
+EndGlobal

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,3 @@
+dotnet restore Fitbit\FitBit.NetCore.sln
+dotnet build Fitbit\FitBit.NetCore.sln
+dotnet test FitBit.NetCore.Tests\FitBit.NetCore.Tests.csproj


### PR DESCRIPTION
This PR adds support for building the library to target .NET Standard 1.3.

In order to maintain compat with older version of .NET Framework, the library is cross-compiled to .NET Framework 4.5 as well.

Changes included:
- Create a new project that targets .NET Standard 1.3. Add file-links to the source code files from the Portable project. 
  - This maintains file history (although git is rather good at tracking files after moves) and keeps a single copy of the source files (important). 
  - The product will also produce a NuGet package (v3.0) with the .NET Framework 4.5 and .NET Standard 1.3 assets.
  - This also keeps the Portable library building for now.
- Create a new unit test project. The unit test project targets .NET Framework 4.6 and consumes the .NET Standard 1.3 library (to test the new version of the code). 
  - Once the test dependencies are updated to support .NET Core we should create a .NET Core unit test project for this.
  - The test files are also file-linked in to keep the portable tests working for now.
- There are a couple of places where the code needed to be slightly changed to accommodate for the .NET Standard 1.3 available APIs. Those places are #if/def-ed under `NETSTANDARD1_3`

This v3.0 branch should merge this PR once it is approved: https://github.com/aarondcoleman/Fitbit.NET/pull/223