### PR TITLE
add IsNullOrWhiteSpace guard for userId param of GetHeartRateTimeSeri…

### DIFF
--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -1030,13 +1030,8 @@ namespace Fitbit.Api.Portable
         /// <returns></returns>
         public async Task<HeartActivitiesTimeSeries> GetHeartRateTimeSeries(DateTime date, DateRangePeriod dateRangePeriod, string userId = "-")
         {
-            if (string.IsNullOrWhiteSpace(userId))
-            {
-                userId = "-";
-            }
-
-            string path = $"1.1/user/{userId}/activities/heart/date/{date:yyyy-MM-dd}/{dateRangePeriod.GetStringValue()}.json";
-            string apiCall = FitbitClientHelperExtensions.ToFullUrl(path);
+            string url = "1.1/user/{0}/" + "activities/heart/date/" + date.ToString("yyyy-MM-dd") + "/"+dateRangePeriod.GetStringValue() + ".json";
+            string apiCall = FitbitClientHelperExtensions.ToFullUrl(url, userId);
             return await ProcessHeartRateTimeSeries(apiCall);
         }
 

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -1030,6 +1030,11 @@ namespace Fitbit.Api.Portable
         /// <returns></returns>
         public async Task<HeartActivitiesTimeSeries> GetHeartRateTimeSeries(DateTime date, DateRangePeriod dateRangePeriod, string userId = "-")
         {
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                userId = "-";
+            }
+
             string path = $"1.1/user/{userId}/activities/heart/date/{date:yyyy-MM-dd}/{dateRangePeriod.GetStringValue()}.json";
             string apiCall = FitbitClientHelperExtensions.ToFullUrl(path);
             return await ProcessHeartRateTimeSeries(apiCall);

--- a/Fitbit.Portable/FitbitClientHelperExtensions.cs
+++ b/Fitbit.Portable/FitbitClientHelperExtensions.cs
@@ -10,10 +10,12 @@ namespace Fitbit.Api.Portable
         /// <summary>
         /// Converts the REST api resource into the fully qualified url
         /// </summary>
-        /// <param name="apiCall"></param>
+        /// <param name="apiCall">
+        ///"Format String" with one "Format Item" as a placeholder for "UserId"
+        ///</param>
         /// <param name="encodedUserId"></param>
         /// <param name="args"></param>
-        /// <returns></returns>
+        /// <returns>Fully qualified url</returns>
         internal static string ToFullUrl(string apiCall, string encodedUserId = default(string), params object[] args)
         {
             string userSignifier = "-"; //used for current user


### PR DESCRIPTION
…es()

This prevents errors in HttpClient if the URL is malformed by omission of userId resulting in user//activities. In this case, the current version of HttpClient exhibits the behvior of switching from https to http (causing a fitbit error)

fixes #235