### PR TITLE
Issue3536 Update Fitbit.NET to .NET 6

### DIFF
--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Platforms>AnyCPU;x64</Platforms>
+	  <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fitbit.Portable.Tests/IntradayTimeSeriesTests.cs
+++ b/Fitbit.Portable.Tests/IntradayTimeSeriesTests.cs
@@ -27,7 +27,7 @@ namespace Fitbit.Portable.Tests
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
             {
                 message.Method.Should().Be(HttpMethod.Get);
-                message.RequestUri.AbsoluteUri.Should().Be("https://api.fitbit.com/1/user/-/activities/calories/date/2015-03-20/1d.json");
+                message.RequestUri.AbsoluteUri.Should().Be("https://api.fitbit.com/1/user/-/activities/calories/date/2015-03-20/1d/1min.json");
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
@@ -52,7 +52,7 @@ namespace Fitbit.Portable.Tests
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
             {
                 message.Method.Should().Be(HttpMethod.Get);
-                message.RequestUri.AbsoluteUri.Should().Be("https://api.fitbit.com/1/user/-/activities/calories/date/2015-03-20/1d.json");
+                message.RequestUri.AbsoluteUri.Should().Be("https://api.fitbit.com/1/user/-/activities/calories/date/2015-03-20/1d/1min.json");
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);
@@ -76,7 +76,7 @@ namespace Fitbit.Portable.Tests
             var verification = new Action<HttpRequestMessage, CancellationToken>((message, token) =>
             {
                 message.Method.Should().Be(HttpMethod.Get);
-                message.RequestUri.AbsoluteUri.Should().Be("https://api.fitbit.com/1/user/-/activities/steps/date/2016-03-08/1d.json");
+                message.RequestUri.AbsoluteUri.Should().Be("https://api.fitbit.com/1/user/-/activities/steps/date/2016-03-08/1d/1min.json");
             });
 
             var fitbitClient = Helper.CreateFitbitClient(responseMessage, verification);

--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <Platforms>AnyCPU;x64</Platforms>
+	  <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Fitbit.Portable/Fitbit.Portable.csproj
+++ b/Fitbit.Portable/Fitbit.Portable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
   
@@ -12,7 +12,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -205,7 +205,7 @@ namespace Fitbit.Api.Portable
             if (interceptors.Count > 0)
             {
                 // inspired by the code referenced from the web api source; this creates the russian doll effect
-                FitbitHttpMessageHandler innerHandler = new FitbitHttpMessageHandler(null, interceptors[0], maxConnectionsPerServer);
+                FitbitHttpMessageHandler innerHandler = new FitbitHttpMessageHandler(null, interceptors[0], maxConnectionsPerServer, socketsHttpHandler);
 
                 var innerHandlers = interceptors.GetRange(1, interceptors.Count - 1);
 

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -200,7 +200,7 @@ namespace Fitbit.Api.Portable
         /// </summary>
         /// <param name="interceptors"></param>
         /// <returns>HttpMessageHandler</returns>
-        public static HttpMessageHandler CreatePipeline(List<IFitbitInterceptor> interceptors, int? maxConnectionsPerServer = null)
+        public static HttpMessageHandler CreatePipeline(List<IFitbitInterceptor> interceptors, int? maxConnectionsPerServer = null, SocketsHttpHandler socketsHttpHandler = null)
         {
             if (interceptors.Count > 0)
             {

--- a/Fitbit.Portable/FitbitHttpMessageHandler.cs
+++ b/Fitbit.Portable/FitbitHttpMessageHandler.cs
@@ -18,21 +18,28 @@
 
         public FitbitClient FitbitClient { get; private set; }
 
-        public FitbitHttpMessageHandler(FitbitClient fitbitClient, IFitbitInterceptor interceptor, int? maxConnectionsPerServer = null)
+        public FitbitHttpMessageHandler(FitbitClient fitbitClient, IFitbitInterceptor interceptor, int? maxConnectionsPerServer = null, SocketsHttpHandler socketsHttpHanlder = null)
         {
             this.FitbitClient = fitbitClient;
             this.interceptor = interceptor;
             responseHandler = ResponseHandler;
 
             //Define the inner must handler. Otherwise exception is thrown.
-            var innerHandler = new HttpClientHandler();
-
-            if (maxConnectionsPerServer != null)
+            if (socketsHttpHanlder != null)
             {
-                innerHandler.MaxConnectionsPerServer = maxConnectionsPerServer.Value;
+                InnerHandler = socketsHttpHanlder;
             }
+            else
+            {
+                var innerHandler = new HttpClientHandler();
 
-            InnerHandler = innerHandler;
+                if (maxConnectionsPerServer != null)
+                {
+                    innerHandler.MaxConnectionsPerServer = maxConnectionsPerServer.Value;
+                }
+
+                InnerHandler = innerHandler;
+            }
         }
 
         //Handle the following method with EXTREME care as it will be invoked on ALL requests made by FitbitClient

--- a/NuGet/package/Fitbit.dev.nuspec
+++ b/NuGet/package/Fitbit.dev.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Fitbit.NET</id>
-    <version>2.3.0$buildNumber$-RC2-Dev</version>
+    <version>2.4.0$buildNumber$-RC2-Dev</version>
     <title>Fitbit.NET</title>
     <authors>Fitbit.Net contributors Team -- @WestDiscGolf, @aarondcoleman, @mxa0079</authors>
     <owners></owners>
@@ -13,9 +13,9 @@
     <description>Fitbit API client for .NET</description>
     <summary>Authenticates with the Fitbit API using OAuth to allow .NET project to make structured calls for a user's data.</summary>
     <releaseNotes>
-      With 2.3.0 Fitbit.NET now targets .NET Standard 2.0
+      With 2.4.0 Fitbit.NET now targets .NET Core 6.0
     </releaseNotes>
-    <copyright>Copyright 2019</copyright>
+    <copyright>Copyright 2024</copyright>
     <tags>Fitbit OAuth2 API</tags>
     <dependencies>
       <dependency id="NETStandard.Library" version="2.0.3" />
@@ -23,7 +23,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="$buildOutputPath$\Fitbit.Portable.dll" target="lib\netstandard2.0" exclude="" />
-    <file src="$buildOutputPath$\Fitbit.Portable.pdb" target="lib\netstandard2.0" exclude="" />
+    <file src="$buildOutputPath$\Fitbit.Portable.dll" target="lib\net6.0" exclude="" />
+    <file src="$buildOutputPath$\Fitbit.Portable.pdb" target="lib\net6.0" exclude="" />
   </files>
 </package>


### PR DESCRIPTION
Migrates Fitbit.NET to .NET Core 6.0.
Adds the ability to pass a `SocketsHttpHandler` to `FitbitHttpMessageHandler` to be used as the inner handler.